### PR TITLE
2024 08 11 should error if erc20 flow from is other than source contract or msg sender test

### DIFF
--- a/test/concrete/flowBasic/FlowTest.sol
+++ b/test/concrete/flowBasic/FlowTest.sol
@@ -278,6 +278,9 @@ contract FlowTest is FlowBasicTest {
 
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
+        vm.assume(bob != address(flow));
+        vm.assume(alise != address(flow));
+
         {
             ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](2);
             erc20Transfers[0] =

--- a/test/concrete/flowBasic/FlowTest.sol
+++ b/test/concrete/flowBasic/FlowTest.sol
@@ -272,7 +272,6 @@ contract FlowTest is FlowBasicTest {
         assumeEtchable(alise, address(flow));
         assumeEtchable(bob, address(flow));
 
-
         {
             ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](2);
             erc20Transfers[0] =

--- a/test/concrete/flowBasic/FlowTest.sol
+++ b/test/concrete/flowBasic/FlowTest.sol
@@ -263,19 +263,15 @@ contract FlowTest is FlowBasicTest {
         address bob,
         uint256 erc20Ammount
     ) external {
-        vm.assume(alise != address(0));
-        vm.assume(sentinel != uint256(uint160(alise)));
-        vm.assume(bob != address(0));
-        vm.assume(sentinel != uint256(uint160(bob)));
         vm.assume(sentinel != erc20Ammount);
         vm.assume(bob != alise);
         vm.label(alise, "Alise");
         vm.label(bob, "Bob");
 
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
+        assumeEtchable(alise, address(flow));
+        assumeEtchable(bob, address(flow));
 
-        vm.assume(bob != address(flow));
-        vm.assume(alise != address(flow));
 
         {
             ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](2);

--- a/test/concrete/flowBasic/FlowTest.sol
+++ b/test/concrete/flowBasic/FlowTest.sol
@@ -278,15 +278,12 @@ contract FlowTest is FlowBasicTest {
 
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
-        address iIERC20B = address(uint160(uint256(keccak256("erc20B.test"))));
-        vm.etch(address(iIERC20B), REVERTING_MOCK_BYTECODE);
-
         {
             ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](2);
             erc20Transfers[0] =
-                ERC20Transfer({token: address(iIERC20), from: bob, to: address(flow), amount: erc20Ammount});
+                ERC20Transfer({token: address(iTokenA), from: bob, to: address(flow), amount: erc20Ammount});
             erc20Transfers[1] =
-                ERC20Transfer({token: address(iIERC20B), from: address(flow), to: alise, amount: erc20Ammount});
+                ERC20Transfer({token: address(iTokenB), from: address(flow), to: alise, amount: erc20Ammount});
 
             uint256[] memory stack =
                 generateTokenTransferStack(new ERC1155Transfer[](0), new ERC721Transfer[](0), erc20Transfers);
@@ -302,9 +299,9 @@ contract FlowTest is FlowBasicTest {
         {
             ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](2);
             erc20Transfers[0] =
-                ERC20Transfer({token: address(iIERC20), from: alise, to: address(flow), amount: erc20Ammount});
-            erc20Transfers[1] = ERC20Transfer({token: address(iIERC20B), from: bob, to: alise, amount: erc20Ammount});
-            vm.mockCall(iIERC20, abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));
+                ERC20Transfer({token: address(iTokenA), from: alise, to: address(flow), amount: erc20Ammount});
+            erc20Transfers[1] = ERC20Transfer({token: address(iTokenB), from: bob, to: alise, amount: erc20Ammount});
+            vm.mockCall(iTokenA, abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));
 
             uint256[] memory stack =
                 generateTokenTransferStack(new ERC1155Transfer[](0), new ERC721Transfer[](0), erc20Transfers);


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Move deprecated "If should error if erc20 flow from is other than source contract or msg sender" test
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Moved deprecated test
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
