### PR TITLE
2024 08 11 should error if erc721 flow from is other than source contract or msg sender test

### DIFF
--- a/test/concrete/flowBasic/FlowTest.sol
+++ b/test/concrete/flowBasic/FlowTest.sol
@@ -334,6 +334,9 @@ contract FlowTest is FlowBasicTest {
 
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
+        vm.assume(bob != address(flow));
+        vm.assume(alise != address(flow));
+        
         {
             ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](2);
             erc721Transfers[0] =

--- a/test/concrete/flowBasic/FlowTest.sol
+++ b/test/concrete/flowBasic/FlowTest.sol
@@ -5,12 +5,14 @@ import {FlowBasicTest} from "test/abstract/FlowBasicTest.sol";
 import {IFlowV5, ERC20Transfer, ERC721Transfer, ERC1155Transfer} from "src/interface/unstable/IFlowV5.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {IERC1155} from "openzeppelin-contracts/contracts/token/ERC1155/IERC1155.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {REVERTING_MOCK_BYTECODE} from "test/abstract/TestConstants.sol";
 import {EvaluableConfigV3, SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 
 contract FlowTest is FlowBasicTest {
     address internal immutable iERC721;
     address internal immutable iERC1155;
+    address internal immutable iIERC20;
 
     constructor() {
         vm.pauseGasMetering();
@@ -19,6 +21,10 @@ contract FlowTest is FlowBasicTest {
 
         iERC1155 = address(uint160(uint256(keccak256("store.rain.test"))));
         vm.etch(address(iERC1155), REVERTING_MOCK_BYTECODE);
+        vm.resumeGasMetering();
+
+        iIERC20 = address(uint160(uint256(keccak256("erc20.test"))));
+        vm.etch(address(iIERC20), REVERTING_MOCK_BYTECODE);
         vm.resumeGasMetering();
     }
 
@@ -76,6 +82,46 @@ contract FlowTest is FlowBasicTest {
         interpreterEval2MockCall(stack, new uint256[](0));
 
         vm.startPrank(alice);
+        flow.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
+        vm.stopPrank();
+    }
+
+    function testFlowERC20ToERC721(address bob, uint256 erc20InAmount, uint256 erc721OutTokenId) external {
+        vm.assume(bob != address(0));
+        vm.assume(sentinel != uint256(uint160(bob)));
+        vm.assume(sentinel != erc20InAmount);
+        vm.assume(sentinel != erc721OutTokenId);
+        vm.label(bob, "Bob");
+
+        (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
+
+        ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](1);
+        erc20Transfers[0] =
+            ERC20Transfer({token: address(iIERC20), from: bob, to: address(flow), amount: erc20InAmount});
+
+        ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](1);
+        erc721Transfers[0] = ERC721Transfer({token: iERC721, from: address(flow), to: bob, id: erc721OutTokenId});
+
+        vm.mockCall(iIERC20, abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));
+        vm.expectCall(iIERC20, abi.encodeWithSelector(IERC20.transferFrom.selector, bob, flow, erc20InAmount));
+
+        vm.mockCall(
+            iERC721,
+            abi.encodeWithSelector(bytes4(keccak256("safeTransferFrom(address,address,uint256)"))),
+            abi.encode()
+        );
+        vm.expectCall(
+            iERC721,
+            abi.encodeWithSelector(
+                bytes4(keccak256("safeTransferFrom(address,address,uint256)")), flow, bob, erc721OutTokenId
+            )
+        );
+
+        uint256[] memory stack = generateTokenTransferStack(new ERC1155Transfer[](0), erc721Transfers, erc20Transfers);
+
+        interpreterEval2MockCall(stack, new uint256[](0));
+
+        vm.startPrank(bob);
         flow.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
         vm.stopPrank();
     }

--- a/test/concrete/flowBasic/FlowTest.sol
+++ b/test/concrete/flowBasic/FlowTest.sol
@@ -272,7 +272,6 @@ contract FlowTest is FlowBasicTest {
         assumeEtchable(alise, address(flow));
         assumeEtchable(bob, address(flow));
 
-
         {
             ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](2);
             erc20Transfers[0] =
@@ -315,20 +314,16 @@ contract FlowTest is FlowBasicTest {
         address bob,
         uint256 erc721TokenId
     ) external {
-        vm.assume(alise != address(0));
-        vm.assume(sentinel != uint256(uint160(alise)));
-        vm.assume(bob != address(0));
-        vm.assume(sentinel != uint256(uint160(bob)));
         vm.assume(sentinel != erc721TokenId);
         vm.assume(bob != alise);
+
         vm.label(alise, "Alise");
         vm.label(bob, "Bob");
 
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
+        assumeEtchable(alise, address(flow));
+        assumeEtchable(bob, address(flow));
 
-        vm.assume(bob != address(flow));
-        vm.assume(alise != address(flow));
-        
         {
             ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](2);
             erc721Transfers[0] =

--- a/test/concrete/flowBasic/FlowTest.sol
+++ b/test/concrete/flowBasic/FlowTest.sol
@@ -332,14 +332,11 @@ contract FlowTest is FlowBasicTest {
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
         {
-            address iERC721B = address(uint160(uint256(keccak256("erc721B.test"))));
-            vm.etch(address(iERC721B), REVERTING_MOCK_BYTECODE);
-
             ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](2);
             erc721Transfers[0] =
-                ERC721Transfer({token: address(iERC721), from: bob, to: address(flow), id: erc721TokenId});
+                ERC721Transfer({token: address(iTokenA), from: bob, to: address(flow), id: erc721TokenId});
             erc721Transfers[1] =
-                ERC721Transfer({token: address(iERC721B), from: address(flow), to: alise, id: erc721TokenId});
+                ERC721Transfer({token: address(iTokenB), from: address(flow), to: alise, id: erc721TokenId});
 
             uint256[] memory stack =
                 generateTokenTransferStack(new ERC1155Transfer[](0), erc721Transfers, new ERC20Transfer[](0));


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Move deprecated "should error if erc721 flow from is other than source contract or msg sender" test
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Moved deprecated test
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
