### PR TITLE
Flowerc1155flow should utilize context in can transfer entrypoint

### DIFF
--- a/test/concrete/flowErc1155/FlowExpressionTest.sol
+++ b/test/concrete/flowErc1155/FlowExpressionTest.sol
@@ -21,7 +21,9 @@ contract FlowExpressionTest is FlowERC1155Test {
      * @dev Tests that the addresses of expressions emitted in the event
      *      match the addresses provided by the deployer.
      */
-    function testFlowERC1155ShouldDeployExpression(address[] memory expressions, string memory uri) public {
+    function testFlowERC1155ShouldDeployExpression(address[] memory expressions, string memory uri, address expression)
+        public
+    {
         uint256 length = bound(expressions.length, 1, 10);
         assembly ("memory-safe") {
             mstore(expressions, length)
@@ -29,7 +31,7 @@ contract FlowExpressionTest is FlowERC1155Test {
 
         uint256[][] memory constants = new uint256[][](expressions.length);
 
-        (, EvaluableV2[] memory evaluables) = deployIFlowERC1155V5(expressions, constants, uri);
+        (, EvaluableV2[] memory evaluables) = deployIFlowERC1155V5(expressions, expression, constants, uri);
 
         for (uint256 i = 0; i < evaluables.length; i++) {
             assertEq(evaluables[i].expression, expressions[i]);

--- a/test/concrete/flowErc1155/FlowMulticallTest.sol
+++ b/test/concrete/flowErc1155/FlowMulticallTest.sol
@@ -41,7 +41,7 @@ contract FlowMulticallTest is FlowERC1155Test {
         uint256[] memory constants = new uint256[](0);
 
         (IFlowERC1155V5 flowErc1155, EvaluableV2[] memory evaluables) =
-            deployIFlowERC1155V5(expressions, constants.matrixFrom(constants), uri);
+            deployIFlowERC1155V5(expressions, expressionB, constants.matrixFrom(constants), uri);
 
         assumeEtchable(bob, address(flowErc1155));
 

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: CAL
+pragma solidity ^0.8.19;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {FlowERC1155} from "../../../src/concrete/erc1155/FlowERC1155.sol";
+import {
+    FlowUtilsAbstractTest,
+    ERC20Transfer,
+    ERC721Transfer,
+    ERC1155Transfer,
+    ERC1155SupplyChange
+} from "test/abstract/FlowUtilsAbstractTest.sol";
+import {IFlowERC1155V5} from "../../../src/interface/unstable/IFlowERC1155V5.sol";
+import {EvaluableV2, SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
+import {FlowERC1155Test} from "../../abstract/FlowERC1155Test.sol";
+import {SignContextLib} from "test/lib/SignContextLib.sol";
+import {DEFAULT_STATE_NAMESPACE} from "rain.interpreter.interface/interface/IInterpreterV2.sol";
+import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpreterStoreV2.sol";
+
+contract FlowTest is FlowUtilsAbstractTest, FlowERC1155Test {
+    using SignContextLib for Vm;
+
+    /// Should utilize context in CAN_TRANSFER entrypoint
+    function testFlowCanTransferEntryPoint(string memory uri, uint256[] memory writeToStore) public {
+        vm.assume(writeToStore.length != 0);
+
+        (IFlowERC1155V5 erc1155Flow, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
+
+        uint256[] memory stack = generateFlowERC1155Stack(
+            new ERC1155Transfer[](0),
+            new ERC721Transfer[](0),
+            new ERC20Transfer[](0),
+            new ERC1155SupplyChange[](0),
+            new ERC1155SupplyChange[](0)
+        );
+
+        interpreterEval2MockCall(stack, writeToStore);
+
+        vm.mockCall(address(iStore), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), abi.encode());
+
+        vm.expectCall(
+            address(iStore),
+            abi.encodeWithSelector(IInterpreterStoreV2.set.selector, DEFAULT_STATE_NAMESPACE, writeToStore)
+        );
+
+        erc1155Flow.flow(evaluable, writeToStore, new SignedContextV1[](0));
+    }
+}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Port should utilize context in CAN_TRANSFER entrypoint hardhat test to foundry test
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Create new test in foundry
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
