### PR TITLE
116 porting legacy tests from flowerc1155flow  test case should flow for erc1155 erc1155 on the good path

### DIFF
--- a/test/abstract/FlowERC1155Test.sol
+++ b/test/abstract/FlowERC1155Test.sol
@@ -10,15 +10,16 @@ import {STUB_EXPRESSION_BYTECODE} from "./TestConstants.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {CloneFactory} from "rain.factory/src/concrete/CloneFactory.sol";
 import {FlowERC1155} from "../../src/concrete/erc1155/FlowERC1155.sol";
+import {REVERTING_MOCK_BYTECODE} from "test/abstract/TestConstants.sol";
 
 abstract contract FlowERC1155Test is FlowUtilsAbstractTest, InterpreterMockTest {
-    CloneFactory internal immutable iCloneFactory;
-    IFlowERC1155V5 internal immutable iFlowImplementation;
+    CloneFactory internal immutable iCloneErc1155Factory;
+    IFlowERC1155V5 internal immutable iFlowErc1155Implementation;
 
     constructor() {
         vm.pauseGasMetering();
-        iCloneFactory = new CloneFactory();
-        iFlowImplementation = new FlowERC1155();
+        iCloneErc1155Factory = new CloneFactory();
+        iFlowErc1155Implementation = new FlowERC1155();
         vm.resumeGasMetering();
     }
 
@@ -36,7 +37,9 @@ abstract contract FlowERC1155Test is FlowUtilsAbstractTest, InterpreterMockTest 
         // Initialize the FlowERC1155ConfigV3 struct
         FlowERC1155ConfigV3 memory flowErc1155Config = FlowERC1155ConfigV3(uri, evaluableConfig, flowConfigArray);
         vm.recordLogs();
-        flowErc1155 = IFlowERC1155V5(iCloneFactory.clone(address(iFlowImplementation), abi.encode(flowErc1155Config)));
+        flowErc1155 = IFlowERC1155V5(
+            iCloneErc1155Factory.clone(address(iFlowErc1155Implementation), abi.encode(flowErc1155Config))
+        );
         Vm.Log[] memory logs = vm.getRecordedLogs();
         Vm.Log memory concreteEvent = findEvent(logs, keccak256("FlowInitialized(address,(address,address,address))"));
         (, evaluable) = abi.decode(concreteEvent.data, (address, EvaluableV2));

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -48,7 +48,6 @@ contract Erc1155FlowTest is FlowUtilsAbstractTest, FlowERC1155Test, FlowBasicTes
         // Ensure the fuzzed key is within the valid range for secp256k1
         uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
         address alice = vm.addr(aliceKey);
-        vm.label(alice, "Alice");
 
         (IFlowERC1155V5 erc1155Flow, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
         assumeEtchable(alice, address(erc1155Flow));
@@ -95,7 +94,6 @@ contract Erc1155FlowTest is FlowUtilsAbstractTest, FlowERC1155Test, FlowBasicTes
         // Ensure the fuzzed key is within the valid range for secp256k1
         uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
         address alice = vm.addr(aliceKey);
-        vm.label(alice, "Alice");
 
         vm.assume(sentinel != erc721OutTokenId);
         vm.assume(sentinel != erc721BInTokenId);

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -4,7 +4,10 @@ pragma solidity ^0.8.18;
 import {Test, Vm} from "forge-std/Test.sol";
 import {FlowBasicTest} from "test/abstract/FlowBasicTest.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
-import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC20Upgradeable as IERC20} from
+    "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
+import {IERC1155Upgradeable as IERC1155} from
+    "openzeppelin-contracts-upgradeable/contracts/token/ERC1155/IERC1155Upgradeable.sol";
 import {REVERTING_MOCK_BYTECODE} from "test/abstract/TestConstants.sol";
 import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {LibEvaluable} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
@@ -126,6 +129,74 @@ contract Erc1155FlowTest is FlowUtilsAbstractTest, FlowERC1155Test, FlowBasicTes
         uint256[] memory stack = generateFlowERC1155Stack(
             new ERC1155Transfer[](0),
             erc721Transfers,
+            new ERC20Transfer[](0),
+            new ERC1155SupplyChange[](0),
+            new ERC1155SupplyChange[](0)
+        );
+        interpreterEval2MockCall(stack, new uint256[](0));
+
+        vm.startPrank(alice);
+        erc1155Flow.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
+        vm.stopPrank();
+    }
+
+    function testFlowERC1155_FlowERC1155ToERC1155(
+        uint256 fuzzedKeyAlice,
+        uint256 erc1155OutTokenId,
+        uint256 erc1155OutAmmount,
+        uint256 erc1155BInTokenId,
+        uint256 erc1155BInAmmount,
+        string memory uri
+    ) external {
+        // Ensure the fuzzed key is within the valid range for secp256k1
+        uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
+        address alice = vm.addr(aliceKey);
+
+        vm.assume(sentinel != erc1155OutTokenId);
+        vm.assume(sentinel != erc1155OutAmmount);
+        vm.assume(sentinel != erc1155BInTokenId);
+        vm.assume(sentinel != erc1155BInAmmount);
+        vm.label(alice, "alice");
+
+        (IFlowERC1155V5 erc1155Flow, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
+        assumeEtchable(alice, address(erc1155Flow));
+
+        ERC1155Transfer[] memory erc1155Transfers = new ERC1155Transfer[](2);
+        erc1155Transfers[0] = ERC1155Transfer({
+            token: address(iTokenA),
+            from: address(erc1155Flow),
+            to: alice,
+            id: erc1155OutTokenId,
+            amount: erc1155OutAmmount
+        });
+
+        erc1155Transfers[1] = ERC1155Transfer({
+            token: address(iTokenB),
+            from: alice,
+            to: address(erc1155Flow),
+            id: erc1155BInTokenId,
+            amount: erc1155BInAmmount
+        });
+
+        vm.mockCall(iTokenA, abi.encodeWithSelector(IERC1155.safeTransferFrom.selector), "");
+        vm.expectCall(
+            iTokenA,
+            abi.encodeWithSelector(
+                IERC1155.safeTransferFrom.selector, erc1155Flow, alice, erc1155OutTokenId, erc1155OutAmmount, ""
+            )
+        );
+
+        vm.mockCall(iTokenB, abi.encodeWithSelector(IERC1155.safeTransferFrom.selector), "");
+        vm.expectCall(
+            iTokenB,
+            abi.encodeWithSelector(
+                IERC1155.safeTransferFrom.selector, alice, erc1155Flow, erc1155BInTokenId, erc1155BInAmmount, ""
+            )
+        );
+
+        uint256[] memory stack = generateFlowERC1155Stack(
+            erc1155Transfers,
+            new ERC721Transfer[](0),
             new ERC20Transfer[](0),
             new ERC1155SupplyChange[](0),
             new ERC1155SupplyChange[](0)

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -140,7 +140,7 @@ contract Erc1155FlowTest is FlowUtilsAbstractTest, FlowERC1155Test, FlowBasicTes
         vm.stopPrank();
     }
 
-    function testFlowERC1155_FlowERC1155ToERC1155(
+    function testFlowERC1155FlowERC1155ToERC1155(
         uint256 fuzzedKeyAlice,
         uint256 erc1155OutTokenId,
         uint256 erc1155OutAmmount,

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: CAL
+pragma solidity ^0.8.18;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {FlowBasicTest} from "test/abstract/FlowBasicTest.sol";
+import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {REVERTING_MOCK_BYTECODE} from "test/abstract/TestConstants.sol";
+import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
+import {LibEvaluable} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
+import {
+    FlowUtilsAbstractTest,
+    ERC20Transfer,
+    ERC721Transfer,
+    ERC1155Transfer,
+    ERC1155SupplyChange
+} from "test/abstract/FlowUtilsAbstractTest.sol";
+import {FlowERC1155Test} from "test/abstract/FlowERC1155Test.sol";
+import {IFlowERC1155V5} from "../../../src/interface/unstable/IFlowERC1155V5.sol";
+import {SignContextLib} from "test/lib/SignContextLib.sol";
+
+contract Erc1155FlowTest is FlowUtilsAbstractTest, FlowERC1155Test, FlowBasicTest {
+    using LibEvaluable for EvaluableV2;
+    using SignContextLib for Vm;
+
+    address internal immutable iTokenA;
+    address internal immutable iTokenB;
+
+    constructor() {
+        vm.pauseGasMetering();
+        iTokenA = address(uint160(uint256(keccak256("tokenA.test"))));
+        vm.etch(address(iTokenA), REVERTING_MOCK_BYTECODE);
+
+        iTokenB = address(uint160(uint256(keccak256("tokenB.test"))));
+        vm.etch(address(iTokenB), REVERTING_MOCK_BYTECODE);
+        vm.resumeGasMetering();
+    }
+
+    function testFlowERC20ToERC20(
+        uint256 erc20OutAmmount,
+        uint256 erc20BInAmmount,
+        string memory uri,
+        uint256 fuzzedKeyAlice
+    ) external {
+        vm.assume(sentinel != erc20OutAmmount);
+        vm.assume(sentinel != erc20BInAmmount);
+
+        // Ensure the fuzzed key is within the valid range for secp256k1
+        uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
+        address alice = vm.addr(aliceKey);
+        vm.label(alice, "Alice");
+
+        (IFlowERC1155V5 erc1155Flow, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
+        assumeEtchable(alice, address(erc1155Flow));
+
+        ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](2);
+        erc20Transfers[0] =
+            ERC20Transfer({token: address(iTokenA), from: address(erc1155Flow), to: alice, amount: erc20OutAmmount});
+        erc20Transfers[1] =
+            ERC20Transfer({token: address(iTokenB), from: alice, to: address(erc1155Flow), amount: erc20BInAmmount});
+
+        vm.startPrank(alice);
+
+        vm.mockCall(iTokenA, abi.encodeWithSelector(IERC20.transfer.selector), abi.encode(true));
+        vm.expectCall(iTokenA, abi.encodeWithSelector(IERC20.transfer.selector, alice, erc20OutAmmount));
+
+        vm.mockCall(iTokenB, abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));
+        vm.expectCall(
+            iTokenB, abi.encodeWithSelector(IERC20.transferFrom.selector, alice, erc1155Flow, erc20BInAmmount)
+        );
+
+        uint256[] memory stack = generateFlowERC1155Stack(
+            new ERC1155Transfer[](0),
+            new ERC721Transfer[](0),
+            new ERC20Transfer[](0),
+            new ERC1155SupplyChange[](0),
+            new ERC1155SupplyChange[](0)
+        );
+        interpreterEval2MockCall(stack, new uint256[](0));
+
+        // With bad signature in second signed context
+        SignedContextV1[] memory signedContexts1 = new SignedContextV1[](2);
+        signedContexts1[0] = vm.signContext(aliceKey, aliceKey, new uint256[](0));
+        signedContexts1[1] = vm.signContext(aliceKey, aliceKey, new uint256[](0));
+
+        erc1155Flow.flow(evaluable, new uint256[](0), signedContexts1);
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Convert 'should flow for ERC1155<->ERC1155 on the good path' hardhat test into foundry test

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Add new foundry test

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs

### Dependencies
- [ ] #117 
