### PR TITLE
63 porting flowerc20flow should flow for erc20 erc721

### DIFF
--- a/test/abstract/FlowERC20Test.sol
+++ b/test/abstract/FlowERC20Test.sol
@@ -11,13 +11,13 @@ import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.so
 import {EvaluableConfigV3} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {STUB_EXPRESSION_BYTECODE} from "./TestConstants.sol";
 
-contract FlowERC20Test is InterpreterMockTest, FlowUtilsAbstractTest {
-    CloneFactory internal immutable iCloneFactory;
+contract FlowERC20Test is FlowUtilsAbstractTest, InterpreterMockTest {
+    CloneFactory internal immutable iCloneErc20Factory;
     IFlowERC20V5 internal immutable iFlowERC20Implementation;
 
     constructor() {
         vm.pauseGasMetering();
-        iCloneFactory = new CloneFactory();
+        iCloneErc20Factory = new CloneFactory();
         iFlowERC20Implementation = new FlowERC20();
         vm.resumeGasMetering();
     }
@@ -36,7 +36,8 @@ contract FlowERC20Test is InterpreterMockTest, FlowUtilsAbstractTest {
         // Initialize the FlowERC20Config struct
         FlowERC20ConfigV2 memory flowErc20Config = FlowERC20ConfigV2(name, symbol, evaluableConfig, flowConfigArray);
         vm.recordLogs();
-        flowErc20 = IFlowERC20V5(iCloneFactory.clone(address(iFlowERC20Implementation), abi.encode(flowErc20Config)));
+        flowErc20 =
+            IFlowERC20V5(iCloneErc20Factory.clone(address(iFlowERC20Implementation), abi.encode(flowErc20Config)));
         Vm.Log[] memory logs = vm.getRecordedLogs();
         Vm.Log memory concreteEvent = findEvent(logs, keccak256("FlowInitialized(address,(address,address,address))"));
         (, evaluable) = abi.decode(concreteEvent.data, (address, EvaluableV2));

--- a/test/concrete/flowErc20/FlowConstructionInitializeTest.sol
+++ b/test/concrete/flowErc20/FlowConstructionInitializeTest.sol
@@ -19,7 +19,7 @@ contract FlowConstructionInitializeTest is FlowERC20Test {
             FlowERC20ConfigV2("Flow ERC20", "F20", EvaluableConfigV3(iDeployer, bytecode, constants), flowConfig);
 
         vm.recordLogs();
-        iCloneFactory.clone(address(iFlowERC20Implementation), abi.encode(flowERC20ConfigV2));
+        iCloneErc20Factory.clone(address(iFlowERC20Implementation), abi.encode(flowERC20ConfigV2));
 
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bytes32 eventSignature =
@@ -28,7 +28,7 @@ contract FlowConstructionInitializeTest is FlowERC20Test {
         Vm.Log memory concreteEvent = findEvent(logs, eventSignature);
         (address sender, FlowERC20ConfigV2 memory config) = abi.decode(concreteEvent.data, (address, FlowERC20ConfigV2));
 
-        assertEq(sender, address(iCloneFactory), "wrong sender in Initialize event");
+        assertEq(sender, address(iCloneErc20Factory), "wrong sender in Initialize event");
         assertEq(keccak256(abi.encode(flowERC20ConfigV2)), keccak256(abi.encode(config)), "wrong compare Structs");
     }
 }

--- a/test/concrete/flowErc20/FlowTest.sol
+++ b/test/concrete/flowErc20/FlowTest.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: CAL
+pragma solidity ^0.8.18;
+
+import {Vm} from "forge-std/Test.sol";
+import {FlowBasicTest} from "test/abstract/FlowBasicTest.sol";
+import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
+import {REVERTING_MOCK_BYTECODE} from "test/abstract/TestConstants.sol";
+import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
+import {LibEvaluable} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
+import {
+    ERC20Transfer,
+    ERC721Transfer,
+    ERC1155Transfer,
+    ERC1155SupplyChange
+} from "test/abstract/FlowUtilsAbstractTest.sol";
+import {FlowERC20Test} from "test/abstract/FlowERC20Test.sol";
+import {IFlowERC20V5} from "../../../src/interface/unstable/IFlowERC20V5.sol";
+import {SignContextLib} from "test/lib/SignContextLib.sol";
+import {IERC20Upgradeable as IERC20} from
+    "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
+
+contract Erc20FlowTest is FlowERC20Test, FlowBasicTest {
+    using LibEvaluable for EvaluableV2;
+    using SignContextLib for Vm;
+
+    address internal immutable iTokenA;
+    address internal immutable iTokenB;
+
+    constructor() {
+        vm.pauseGasMetering();
+        iTokenA = address(uint160(uint256(keccak256("tokenA.test"))));
+        vm.etch(address(iTokenA), REVERTING_MOCK_BYTECODE);
+
+        iTokenB = address(uint160(uint256(keccak256("tokenB.test"))));
+        vm.etch(address(iTokenB), REVERTING_MOCK_BYTECODE);
+        vm.resumeGasMetering();
+    }
+
+    function testFlowERC20FlowERC20ToERC721(
+        uint256 fuzzedKeyAlice,
+        uint256 erc20InAmount,
+        uint256 erc721OutTokenId,
+        string memory name,
+        string memory symbol
+    ) external {
+        // Ensure the fuzzed key is within the valid range for secp256k1
+        uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
+        address alice = vm.addr(aliceKey);
+
+        vm.assume(sentinel != erc20InAmount);
+        vm.assume(sentinel != erc721OutTokenId);
+
+        (IFlowERC20V5 erc20Flow, EvaluableV2 memory evaluable) = deployFlowERC20(name, symbol);
+        assumeEtchable(alice, address(erc20Flow));
+
+        ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](1);
+        erc20Transfers[0] =
+            ERC20Transfer({token: address(iTokenA), from: alice, to: address(erc20Flow), amount: erc20InAmount});
+
+        ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](1);
+        erc721Transfers[0] = ERC721Transfer({token: iTokenB, from: address(erc20Flow), to: alice, id: erc721OutTokenId});
+
+        vm.mockCall(iTokenA, abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));
+        vm.expectCall(iTokenA, abi.encodeWithSelector(IERC20.transferFrom.selector, alice, erc20Flow, erc20InAmount));
+
+        vm.mockCall(iTokenB, abi.encodeWithSelector(bytes4(keccak256("safeTransferFrom(address,address,uint256)"))), "");
+        vm.expectCall(
+            iTokenB,
+            abi.encodeWithSelector(
+                bytes4(keccak256("safeTransferFrom(address,address,uint256)")), erc20Flow, alice, erc721OutTokenId
+            )
+        );
+
+        uint256[] memory stack = generateFlowERC1155Stack(
+            new ERC1155Transfer[](0),
+            erc721Transfers,
+            erc20Transfers,
+            new ERC1155SupplyChange[](0),
+            new ERC1155SupplyChange[](0)
+        );
+        interpreterEval2MockCall(stack, new uint256[](0));
+
+        vm.startPrank(alice);
+        erc20Flow.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Porting flowerc20flow should flow for erc20 <> erc721
Porting flowerc20flow should flow for erc721 <> erc721
Porting flowerc20flow should flow for erc1155 <> erc1155

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add new test in foundry
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs

### Dependencies
- [x] #79 
