### PR TITLE
Update deployIFlowERC1155V5 function and add overloads

### DIFF
--- a/test/abstract/FlowERC1155Test.sol
+++ b/test/abstract/FlowERC1155Test.sol
@@ -2,17 +2,17 @@
 pragma solidity ^0.8.18;
 
 import {Vm} from "forge-std/Test.sol";
-import {FlowUtilsAbstractTest} from "test/abstract/FlowUtilsAbstractTest.sol";
-import {InterpreterMockTest} from "test/abstract/InterpreterMockTest.sol";
 import {IFlowERC1155V5, FlowERC1155ConfigV3} from "src/interface/unstable/IFlowERC1155V5.sol";
 import {EvaluableConfigV3} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
-import {STUB_EXPRESSION_BYTECODE} from "./TestConstants.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {CloneFactory} from "rain.factory/src/concrete/CloneFactory.sol";
 import {FlowERC1155} from "../../src/concrete/erc1155/FlowERC1155.sol";
-import {REVERTING_MOCK_BYTECODE} from "test/abstract/TestConstants.sol";
+import {LibUint256Matrix} from "rain.solmem/lib/LibUint256Matrix.sol";
+import {FlowBasicTest} from "test/abstract/FlowBasicTest.sol";
 
-abstract contract FlowERC1155Test is FlowUtilsAbstractTest, InterpreterMockTest {
+abstract contract FlowERC1155Test is FlowBasicTest {
+    using LibUint256Matrix for uint256[];
+
     CloneFactory internal immutable iCloneErc1155Factory;
     IFlowERC1155V5 internal immutable iFlowErc1155Implementation;
 
@@ -27,21 +27,64 @@ abstract contract FlowERC1155Test is FlowUtilsAbstractTest, InterpreterMockTest 
         internal
         returns (IFlowERC1155V5 flowErc1155, EvaluableV2 memory evaluable)
     {
-        expressionDeployerDeployExpression2MockCall(address(0), bytes(hex"0006"));
-        // Create the evaluableConfig
-        EvaluableConfigV3 memory evaluableConfig =
-            EvaluableConfigV3(iDeployer, STUB_EXPRESSION_BYTECODE, new uint256[](0));
-        // Create the flowConfig array with one entry
-        EvaluableConfigV3[] memory flowConfigArray = new EvaluableConfigV3[](1);
-        flowConfigArray[0] = evaluableConfig;
-        // Initialize the FlowERC1155ConfigV3 struct
-        FlowERC1155ConfigV3 memory flowErc1155Config = FlowERC1155ConfigV3(uri, evaluableConfig, flowConfigArray);
-        vm.recordLogs();
-        flowErc1155 = IFlowERC1155V5(
-            iCloneErc1155Factory.clone(address(iFlowErc1155Implementation), abi.encode(flowErc1155Config))
-        );
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        Vm.Log memory concreteEvent = findEvent(logs, keccak256("FlowInitialized(address,(address,address,address))"));
-        (, evaluable) = abi.decode(concreteEvent.data, (address, EvaluableV2));
+        (flowErc1155, evaluable) = deployIFlowERC1155V5(address(0), uri);
+    }
+
+    function deployIFlowERC1155V5(address expression, string memory uri)
+        internal
+        returns (IFlowERC1155V5, EvaluableV2 memory)
+    {
+        address[] memory expressions = new address[](1);
+        expressions[0] = expression;
+        uint256[] memory constants = new uint256[](0);
+        (IFlowERC1155V5 flowErc1155, EvaluableV2[] memory evaluables) =
+            deployIFlowERC1155V5(expressions, constants.matrixFrom(), uri);
+        return (flowErc1155, evaluables[0]);
+    }
+
+    function deployIFlowERC1155V5(address[] memory expressions, uint256[][] memory constants, string memory uri)
+        internal
+        returns (IFlowERC1155V5 flowErc1155, EvaluableV2[] memory evaluables)
+    {
+        require(expressions.length == constants.length, "Expressions and constants array lengths must match");
+
+        {
+            EvaluableConfigV3[] memory flowConfig = new EvaluableConfigV3[](expressions.length);
+
+            for (uint256 i = 0; i < expressions.length; i++) {
+                bytes memory generatedBytecode = abi.encodePacked(vm.addr(i + 1));
+                expressionDeployerDeployExpression2MockCall(
+                    generatedBytecode, constants[i], expressions[i], bytes(hex"0006")
+                );
+
+                flowConfig[i] = EvaluableConfigV3(iDeployer, generatedBytecode, constants[i]);
+            }
+
+            // Initialize the FlowERC1155Config struct
+            FlowERC1155ConfigV3 memory flowErc1155Config = FlowERC1155ConfigV3(uri, flowConfig[0], flowConfig);
+
+            for (uint256 i = 0; i < expressions.length; i++) {
+                bytes memory generatedBytecode = abi.encodePacked(vm.addr(i + 1));
+                expressionDeployerDeployExpression2MockCall(
+                    generatedBytecode, constants[i], expressions[i], bytes(hex"0006")
+                );
+
+                flowConfig[i] = EvaluableConfigV3(iDeployer, generatedBytecode, constants[i]);
+            }
+
+            vm.recordLogs();
+            flowErc1155 =
+                IFlowERC1155V5(iCloneFactory.clone(address(iFlowErc1155Implementation), abi.encode(flowErc1155Config)));
+        }
+
+        {
+            Vm.Log[] memory logs = vm.getRecordedLogs();
+            logs = findEvents(logs, keccak256("FlowInitialized(address,(address,address,address))"));
+            evaluables = new EvaluableV2[](logs.length);
+            for (uint256 i = 0; i < logs.length; i++) {
+                (, EvaluableV2 memory evaluable) = abi.decode(logs[i].data, (address, EvaluableV2));
+                evaluables[i] = evaluable;
+            }
+        }
     }
 }

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.18;
 
 import {Test, Vm} from "forge-std/Test.sol";
-import {FlowBasicTest} from "test/abstract/FlowBasicTest.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {IERC20Upgradeable as IERC20} from
     "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
@@ -14,13 +13,11 @@ import {FlowTransferV1, ERC20Transfer, ERC721Transfer, ERC1155Transfer} from "sr
 import {
     IFlowERC1155V5, ERC1155SupplyChange, FlowERC1155IOV1
 } from "../../../src/interface/unstable/IFlowERC1155V5.sol";
-import {FlowUtilsAbstractTest} from "test/abstract/FlowUtilsAbstractTest.sol";
-
 import {FlowERC1155Test} from "test/abstract/FlowERC1155Test.sol";
 import {IFlowERC1155V5} from "../../../src/interface/unstable/IFlowERC1155V5.sol";
 import {SignContextLib} from "test/lib/SignContextLib.sol";
 
-contract Erc1155FlowTest is FlowUtilsAbstractTest, FlowERC1155Test, FlowBasicTest {
+contract Erc1155FlowTest is FlowERC1155Test {
     using LibEvaluable for EvaluableV2;
     using SignContextLib for Vm;
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Porting legacy tests from ".FlowERC1155/multicall" — test case "should call multiple flows from same flow contract at once using multicall"

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add new test in foundry
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
