### PR TITLE
112 porting legacy tests from flowerc1155flow  test case should support transferpreflight hook

### DIFF
--- a/test/abstract/FlowERC1155Test.sol
+++ b/test/abstract/FlowERC1155Test.sol
@@ -23,21 +23,6 @@ abstract contract FlowERC1155Test is FlowBasicTest {
         vm.resumeGasMetering();
     }
 
-    function expressionDeployer(address expression, uint256[] memory constants, bytes memory bytecode)
-        internal
-        returns (EvaluableConfigV3 memory)
-    {
-        expressionDeployerDeployExpression2MockCall(bytecode, constants, expression, bytes(hex"0006"));
-        return EvaluableConfigV3(iDeployer, bytecode, constants);
-    }
-
-    function expressionDeployer(uint256 key, address expression, uint256[] memory constants)
-        internal
-        returns (EvaluableConfigV3 memory)
-    {
-        return expressionDeployer(expression, constants, abi.encodePacked(vm.addr(key)));
-    }
-
     function deployIFlowERC1155V5(string memory uri)
         internal
         returns (IFlowERC1155V5 flowErc1155, EvaluableV2 memory evaluable)

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -13,15 +13,27 @@ import {IInterpreterV2, DEFAULT_STATE_NAMESPACE} from "rain.interpreter.interfac
 import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpreterStoreV2.sol";
 import {FlowTransferV1, ERC20Transfer, ERC721Transfer, ERC1155Transfer} from "src/interface/unstable/IFlowV5.sol";
 import {
-    IFlowERC1155V5, ERC1155SupplyChange, FlowERC1155IOV1
+    IFlowERC1155V5,
+    ERC1155SupplyChange,
+    FlowERC1155IOV1,
+    FLOW_ERC1155_HANDLE_TRANSFER_ENTRYPOINT,
+    FLOW_ERC1155_HANDLE_TRANSFER_MAX_OUTPUTS
 } from "../../../src/interface/unstable/IFlowERC1155V5.sol";
 import {FlowERC1155Test} from "test/abstract/FlowERC1155Test.sol";
 import {IFlowERC1155V5} from "../../../src/interface/unstable/IFlowERC1155V5.sol";
+import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
 import {SignContextLib} from "test/lib/SignContextLib.sol";
+import {LibUint256Array} from "rain.solmem/lib/LibUint256Array.sol";
+import {LibUint256Matrix} from "rain.solmem/lib/LibUint256Matrix.sol";
+import {LibContextWrapper} from "test/lib/LibContextWrapper.sol";
+import {LibEncodedDispatch} from "rain.interpreter.interface/lib/caller/LibEncodedDispatch.sol";
 
 contract Erc1155FlowTest is FlowERC1155Test {
     using LibEvaluable for EvaluableV2;
     using SignContextLib for Vm;
+    using Address for address;
+    using LibUint256Matrix for uint256[];
+    using LibUint256Array for uint256[];
 
     function testFlowERC1155FlowERC20ToERC20(
         uint256 erc20OutAmmount,
@@ -257,6 +269,7 @@ contract Erc1155FlowTest is FlowERC1155Test {
         vm.assume(sentinel != amount);
         vm.assume(expressionA != expressionB);
         vm.assume(writeToStore.length != 0);
+        vm.assume(!alice.isContract());
 
         address[] memory expressions = new address[](1);
         expressions[0] = expressionA;


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Porting legacy tests from flowerc1155flow  test case should support transferpreflight hook

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add new foundry test
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
