### PR TITLE
114 porting legacy tests from flowerc1155flow  test case should flow for erc721 erc1155 on the good path

### DIFF
--- a/test/abstract/FlowERC1155Test.sol
+++ b/test/abstract/FlowERC1155Test.sol
@@ -23,21 +23,6 @@ abstract contract FlowERC1155Test is FlowBasicTest {
         vm.resumeGasMetering();
     }
 
-    function expressionDeployer(address expression, uint256[] memory constants, bytes memory bytecode)
-        internal
-        returns (EvaluableConfigV3 memory)
-    {
-        expressionDeployerDeployExpression2MockCall(bytecode, constants, expression, bytes(hex"0006"));
-        return EvaluableConfigV3(iDeployer, bytecode, constants);
-    }
-
-    function expressionDeployer(uint256 key, address expression, uint256[] memory constants)
-        internal
-        returns (EvaluableConfigV3 memory)
-    {
-        return expressionDeployer(expression, constants, abi.encodePacked(vm.addr(key)));
-    }
-
     function deployIFlowERC1155V5(string memory uri)
         internal
         returns (IFlowERC1155V5 flowErc1155, EvaluableV2 memory evaluable)

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -23,6 +23,77 @@ contract Erc1155FlowTest is FlowERC1155Test {
     using LibEvaluable for EvaluableV2;
     using SignContextLib for Vm;
 
+    /// Tests the flow between ERC721 and ERC1155 on the good path.
+    function testFlowERC1155FlowERC721ToERC1155(
+        address alice,
+        uint256 erc721InTokenId,
+        uint256 erc1155OutTokenId,
+        uint256 erc1155OutAmmount,
+        string memory uri,
+        uint256 id
+    ) external {
+        vm.assume(sentinel != erc721InTokenId);
+        vm.assume(sentinel != erc1155OutTokenId);
+        vm.assume(sentinel != erc1155OutAmmount);
+        vm.assume(address(0) != alice);
+
+        vm.label(alice, "Alice");
+
+        (IFlowERC1155V5 flowErc1155, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
+
+        assumeEtchable(alice, address(flowErc1155));
+
+        {
+            ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](1);
+            erc721Transfers[0] =
+                ERC721Transfer({token: address(iTokenA), from: alice, to: address(flowErc1155), id: erc721InTokenId});
+
+            ERC1155Transfer[] memory erc1155Transfers = new ERC1155Transfer[](1);
+            erc1155Transfers[0] = ERC1155Transfer({
+                token: address(iTokenB),
+                from: address(flowErc1155),
+                to: alice,
+                id: erc1155OutTokenId,
+                amount: erc1155OutAmmount
+            });
+
+            ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
+            mints[0] = ERC1155SupplyChange({account: alice, id: id, amount: 20 ether});
+
+            ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
+            burns[0] = ERC1155SupplyChange({account: alice, id: id, amount: 10 ether});
+
+            uint256[] memory stack = generateFlowStack(
+                FlowERC1155IOV1(mints, burns, FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, erc1155Transfers))
+            );
+            interpreterEval2MockCall(stack, new uint256[](0));
+        }
+
+        {
+            vm.mockCall(iTokenB, abi.encodeWithSelector(IERC1155.safeTransferFrom.selector), "");
+            vm.expectCall(
+                iTokenB,
+                abi.encodeWithSelector(
+                    IERC1155.safeTransferFrom.selector, flowErc1155, alice, erc1155OutTokenId, erc1155OutAmmount, ""
+                )
+            );
+
+            vm.mockCall(
+                iTokenA, abi.encodeWithSelector(bytes4(keccak256("safeTransferFrom(address,address,uint256)"))), ""
+            );
+            vm.expectCall(
+                iTokenA,
+                abi.encodeWithSelector(
+                    bytes4(keccak256("safeTransferFrom(address,address,uint256)")), alice, flowErc1155, erc721InTokenId
+                )
+            );
+        }
+
+        vm.startPrank(alice);
+        flowErc1155.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
+        vm.stopPrank();
+    }
+
     function testFlowERC1155FlowERC20ToERC20(
         uint256 erc20OutAmmount,
         uint256 erc20BInAmmount,


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Porting legacy tests from flowerc1155flow  test case should flow for erc721 erc1155 on the good path
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add new test in founrdy
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
