### PR TITLE
218 fix missing minting and burning in erc20 flow tests

### DIFF
--- a/test/abstract/FlowERC1155Test.sol
+++ b/test/abstract/FlowERC1155Test.sol
@@ -23,21 +23,6 @@ abstract contract FlowERC1155Test is FlowBasicTest {
         vm.resumeGasMetering();
     }
 
-    function expressionDeployer(address expression, uint256[] memory constants, bytes memory bytecode)
-        internal
-        returns (EvaluableConfigV3 memory)
-    {
-        expressionDeployerDeployExpression2MockCall(bytecode, constants, expression, bytes(hex"0006"));
-        return EvaluableConfigV3(iDeployer, bytecode, constants);
-    }
-
-    function expressionDeployer(uint256 key, address expression, uint256[] memory constants)
-        internal
-        returns (EvaluableConfigV3 memory)
-    {
-        return expressionDeployer(expression, constants, abi.encodePacked(vm.addr(key)));
-    }
-
     function deployIFlowERC1155V5(string memory uri)
         internal
         returns (IFlowERC1155V5 flowErc1155, EvaluableV2 memory evaluable)

--- a/test/concrete/flowErc20/FlowExpressionTest.sol
+++ b/test/concrete/flowErc20/FlowExpressionTest.sol
@@ -50,18 +50,26 @@ contract FlowExpressionTest is FlowERC20Test {
         uint256[] memory fuzzedcallerContext0,
         uint256[] memory fuzzedcallerContext1,
         string memory name,
-        string memory symbol
+        string memory symbol,
+        address alice
     ) public {
+        vm.assume(alice != address(0));
         uint256[][] memory matrixCallerContext =
             fuzzedcallerContext0.matrixFrom(fuzzedcallerContext1, fuzzedcallerContext0);
 
         (IFlowERC20V5 flowErc20, EvaluableV2 memory evaluable) = deployFlowERC20(name, symbol);
 
+        ERC20SupplyChange[] memory mints = new ERC20SupplyChange[](1);
+        mints[0] = ERC20SupplyChange({account: alice, amount: 20 ether});
+
+        ERC20SupplyChange[] memory burns = new ERC20SupplyChange[](1);
+        burns[0] = ERC20SupplyChange({account: alice, amount: 10 ether});
+
         {
             uint256[] memory stack = generateFlowStack(
                 FlowERC20IOV1(
-                    new ERC20SupplyChange[](0),
-                    new ERC20SupplyChange[](0),
+                    mints,
+                    burns,
                     FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
                 )
             );

--- a/test/concrete/flowErc20/FlowMulticallTest.sol
+++ b/test/concrete/flowErc20/FlowMulticallTest.sol
@@ -103,11 +103,7 @@ contract FlowMulticallTest is FlowERC20Test {
             burns[0] = ERC20SupplyChange({account: bob, amount: 10 ether});
 
             uint256[] memory stack = generateFlowStack(
-                FlowERC20IOV1(
-                    mints,
-                    burns,
-                    FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, erc1155Transfers)
-                )
+                FlowERC20IOV1(mints, burns, FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, erc1155Transfers))
             );
 
             interpreterEval2MockCall(

--- a/test/concrete/flowErc20/FlowMulticallTest.sol
+++ b/test/concrete/flowErc20/FlowMulticallTest.sol
@@ -46,7 +46,7 @@ contract FlowMulticallTest is FlowERC20Test {
 
         assumeEtchable(bob, address(flow));
 
-        //Flow A
+        // Flow A
         {
             ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](1);
             erc721Transfers[0] = ERC721Transfer({token: address(iTokenA), from: address(flow), to: bob, id: tokenId});
@@ -87,7 +87,7 @@ contract FlowMulticallTest is FlowERC20Test {
             vm.expectCall(iTokenB, abi.encodeWithSelector(IERC20.transferFrom.selector, bob, flow, amount));
         }
 
-        //Flow B
+        // Flow B
         {
             ERC1155Transfer[] memory erc1155Transfers = new ERC1155Transfer[](1);
             erc1155Transfers[0] =
@@ -96,10 +96,16 @@ contract FlowMulticallTest is FlowERC20Test {
             ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](1);
             erc721Transfers[0] = ERC721Transfer({token: address(iTokenA), from: bob, to: address(flow), id: tokenId});
 
+            ERC20SupplyChange[] memory mints = new ERC20SupplyChange[](1);
+            mints[0] = ERC20SupplyChange({account: bob, amount: 20 ether});
+
+            ERC20SupplyChange[] memory burns = new ERC20SupplyChange[](1);
+            burns[0] = ERC20SupplyChange({account: bob, amount: 10 ether});
+
             uint256[] memory stack = generateFlowStack(
                 FlowERC20IOV1(
-                    new ERC20SupplyChange[](0),
-                    new ERC20SupplyChange[](0),
+                    mints,
+                    burns,
                     FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, erc1155Transfers)
                 )
             );

--- a/test/concrete/flowErc20/FlowSignedContextTest.sol
+++ b/test/concrete/flowErc20/FlowSignedContextTest.sol
@@ -86,17 +86,24 @@ contract FlowSignedContextTest is FlowUtilsAbstractTest, FlowERC20Test {
 
         SignedContextV1[] memory signedContext = new SignedContextV1[](1);
         signedContext[0] = vm.signContext(aliceKey, aliceKey, context0);
+        {
+            address alice = vm.addr(aliceKey);
+            ERC20SupplyChange[] memory mints = new ERC20SupplyChange[](1);
+            mints[0] = ERC20SupplyChange({account: alice, amount: 20 ether});
 
-        uint256[] memory stack = generateFlowStack(
-            FlowERC20IOV1(
-                new ERC20SupplyChange[](0),
-                new ERC20SupplyChange[](0),
-                FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
-            )
-        );
-        interpreterEval2MockCall(stack, new uint256[](0));
-        erc20Flow.flow(evaluable, new uint256[](0), signedContext);
+            ERC20SupplyChange[] memory burns = new ERC20SupplyChange[](1);
+            burns[0] = ERC20SupplyChange({account: alice, amount: 10 ether});
 
+            uint256[] memory stack = generateFlowStack(
+                FlowERC20IOV1(
+                    mints,
+                    burns,
+                    FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
+                )
+            );
+            interpreterEval2MockCall(stack, new uint256[](0));
+            erc20Flow.flow(evaluable, new uint256[](0), signedContext);
+        }
         // With bad signature in second signed context
         SignedContextV1[] memory signedContext1 = new SignedContextV1[](1);
         signedContext1[0] = vm.signContext(aliceKey, bobKey, context0);

--- a/test/concrete/flowErc20/FlowSignedContextTest.sol
+++ b/test/concrete/flowErc20/FlowSignedContextTest.sol
@@ -34,30 +34,37 @@ contract FlowSignedContextTest is FlowUtilsAbstractTest, FlowERC20Test {
         signedContexts[0] = vm.signContext(aliceKey, aliceKey, context0);
         signedContexts[1] = vm.signContext(aliceKey, aliceKey, context1);
 
-        uint256[] memory stack = generateFlowStack(
-            FlowERC20IOV1(
-                new ERC20SupplyChange[](0),
-                new ERC20SupplyChange[](0),
-                FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
-            )
-        );
-        interpreterEval2MockCall(stack, new uint256[](0));
-        erc20Flow.flow(evaluable, new uint256[](0), signedContexts);
+        {
+            address alice = vm.addr(aliceKey);
+            ERC20SupplyChange[] memory mints = new ERC20SupplyChange[](1);
+            mints[0] = ERC20SupplyChange({account: alice, amount: 20 ether});
 
+            ERC20SupplyChange[] memory burns = new ERC20SupplyChange[](1);
+            burns[0] = ERC20SupplyChange({account: alice, amount: 10 ether});
+
+            uint256[] memory stack = generateFlowStack(
+                FlowERC20IOV1(
+                    mints,
+                    burns,
+                    FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
+                )
+            );
+            interpreterEval2MockCall(stack, new uint256[](0));
+            erc20Flow.flow(evaluable, new uint256[](0), signedContexts);
+
+            uint256[] memory stack1 = generateFlowStack(
+                FlowERC20IOV1(
+                    mints,
+                    burns,
+                    FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
+                )
+            );
+            interpreterEval2MockCall(stack1, new uint256[](0));
+        }
         // With bad signature in second signed context
         SignedContextV1[] memory signedContexts1 = new SignedContextV1[](2);
         signedContexts1[0] = vm.signContext(aliceKey, aliceKey, context0);
         signedContexts1[1] = vm.signContext(aliceKey, bobKey, context1);
-
-        uint256[] memory stack1 = generateFlowStack(
-            FlowERC20IOV1(
-                new ERC20SupplyChange[](0),
-                new ERC20SupplyChange[](0),
-                FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
-            )
-        );
-        interpreterEval2MockCall(stack1, new uint256[](0));
-
         vm.expectRevert(abi.encodeWithSelector(InvalidSignature.selector, 1));
         erc20Flow.flow(evaluable, new uint256[](0), signedContexts1);
     }

--- a/test/concrete/flowErc20/FlowTest.sol
+++ b/test/concrete/flowErc20/FlowTest.sol
@@ -273,6 +273,9 @@ contract Erc20FlowTest is FlowERC20Test {
         vm.stopPrank();
     }
 
+    /**
+     * @notice Tests the flow between ERC20 and ERC721 on the good path.
+     */
     function testFlowERC20FlowERC20ToERC721(
         uint256 fuzzedKeyAlice,
         uint256 erc20InAmount,
@@ -324,6 +327,9 @@ contract Erc20FlowTest is FlowERC20Test {
         vm.stopPrank();
     }
 
+    /**
+     * @notice Tests the flow between ERC1155 and ERC1155 on the good path.
+     */
     function testFlowERC20FlowERC1155ToERC1155(
         uint256 fuzzedKeyAlice,
         uint256 erc1155OutTokenId,
@@ -394,6 +400,9 @@ contract Erc20FlowTest is FlowERC20Test {
         vm.stopPrank();
     }
 
+    /**
+     * @notice Tests the flow between ERC721 and ERC721 on the good path.
+     */
     function testFlowERC20FlowERC721ToERC721(
         uint256 fuzzedKeyAlice,
         uint256 erc721OutTokenId,
@@ -452,6 +461,9 @@ contract Erc20FlowTest is FlowERC20Test {
         vm.stopPrank();
     }
 
+    /**
+     * @notice Tests the flow between ERC20 and ERC20 on the good path.
+     */
     function testFlowERC20FlowERC20ToERC20(
         uint256 erc20OutAmmount,
         uint256 erc20BInAmmount,

--- a/test/concrete/flowErc20/FlowTest.sol
+++ b/test/concrete/flowErc20/FlowTest.sol
@@ -433,11 +433,15 @@ contract Erc20FlowTest is FlowERC20Test {
             )
         );
 
+        ERC20SupplyChange[] memory mints = new ERC20SupplyChange[](1);
+        mints[0] = ERC20SupplyChange({account: alice, amount: 20 ether});
+
+        ERC20SupplyChange[] memory burns = new ERC20SupplyChange[](1);
+        burns[0] = ERC20SupplyChange({account: alice, amount: 10 ether});
+
         uint256[] memory stack = generateFlowStack(
             FlowERC20IOV1(
-                new ERC20SupplyChange[](0),
-                new ERC20SupplyChange[](0),
-                FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, new ERC1155Transfer[](0))
+                mints, burns, FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, new ERC1155Transfer[](0))
             )
         );
 

--- a/test/concrete/flowErc20/FlowTest.sol
+++ b/test/concrete/flowErc20/FlowTest.sol
@@ -308,12 +308,14 @@ contract Erc20FlowTest is FlowERC20Test {
             )
         );
 
+        ERC20SupplyChange[] memory mints = new ERC20SupplyChange[](1);
+        mints[0] = ERC20SupplyChange({account: alice, amount: 20 ether});
+
+        ERC20SupplyChange[] memory burns = new ERC20SupplyChange[](1);
+        burns[0] = ERC20SupplyChange({account: alice, amount: 10 ether});
+
         uint256[] memory stack = generateFlowStack(
-            FlowERC20IOV1(
-                new ERC20SupplyChange[](0),
-                new ERC20SupplyChange[](0),
-                FlowTransferV1(erc20Transfers, erc721Transfers, new ERC1155Transfer[](0))
-            )
+            FlowERC20IOV1(mints, burns, FlowTransferV1(erc20Transfers, erc721Transfers, new ERC1155Transfer[](0)))
         );
         interpreterEval2MockCall(stack, new uint256[](0));
 

--- a/test/concrete/flowErc20/FlowTest.sol
+++ b/test/concrete/flowErc20/FlowTest.sol
@@ -485,11 +485,15 @@ contract Erc20FlowTest is FlowERC20Test {
             address(iTokenB), abi.encodeWithSelector(IERC20.transferFrom.selector, alice, erc20Flow, erc20BInAmmount)
         );
 
+        ERC20SupplyChange[] memory mints = new ERC20SupplyChange[](1);
+        mints[0] = ERC20SupplyChange({account: alice, amount: 20 ether});
+
+        ERC20SupplyChange[] memory burns = new ERC20SupplyChange[](1);
+        burns[0] = ERC20SupplyChange({account: alice, amount: 10 ether});
+
         uint256[] memory stack = generateFlowStack(
             FlowERC20IOV1(
-                new ERC20SupplyChange[](0),
-                new ERC20SupplyChange[](0),
-                FlowTransferV1(erc20Transfers, new ERC721Transfer[](0), new ERC1155Transfer[](0))
+                mints, burns, FlowTransferV1(erc20Transfers, new ERC721Transfer[](0), new ERC1155Transfer[](0))
             )
         );
         interpreterEval2MockCall(stack, new uint256[](0));

--- a/test/concrete/flowErc20/FlowTest.sol
+++ b/test/concrete/flowErc20/FlowTest.sol
@@ -376,12 +376,15 @@ contract Erc20FlowTest is FlowERC20Test {
                 IERC1155.safeTransferFrom.selector, alice, erc20Flow, erc1155BInTokenId, erc1155BInAmmount, ""
             )
         );
+        ERC20SupplyChange[] memory mints = new ERC20SupplyChange[](1);
+        mints[0] = ERC20SupplyChange({account: alice, amount: 20 ether});
+
+        ERC20SupplyChange[] memory burns = new ERC20SupplyChange[](1);
+        burns[0] = ERC20SupplyChange({account: alice, amount: 10 ether});
 
         uint256[] memory stack = generateFlowStack(
             FlowERC20IOV1(
-                new ERC20SupplyChange[](0),
-                new ERC20SupplyChange[](0),
-                FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), erc1155Transfers)
+                mints, burns, FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), erc1155Transfers)
             )
         );
 

--- a/test/concrete/flowErc20/FlowTimeTest.sol
+++ b/test/concrete/flowErc20/FlowTimeTest.sol
@@ -14,15 +14,25 @@ import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpr
 contract FlowTimeTest is FlowERC20Test {
     using SignContextLib for Vm;
 
-    function testFlowERC20FlowTime(string memory name, string memory symbol, uint256[] memory writeToStore) public {
+    function testFlowERC20FlowTime(
+        string memory name,
+        string memory symbol,
+        uint256[] memory writeToStore,
+        address alice
+    ) public {
+        vm.assume(alice != address(0));
         vm.assume(writeToStore.length != 0);
         (IFlowERC20V5 erc20Flow, EvaluableV2 memory evaluable) = deployFlowERC20(name, symbol);
 
+        ERC20SupplyChange[] memory mints = new ERC20SupplyChange[](1);
+        mints[0] = ERC20SupplyChange({account: alice, amount: 20 ether});
+
+        ERC20SupplyChange[] memory burns = new ERC20SupplyChange[](1);
+        burns[0] = ERC20SupplyChange({account: alice, amount: 10 ether});
+
         uint256[] memory stack = generateFlowStack(
             FlowERC20IOV1(
-                new ERC20SupplyChange[](0),
-                new ERC20SupplyChange[](0),
-                FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
+                mints, burns, FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
             )
         );
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
In erc20 flow test, minting and burning were empty. Essentially, that was re-testing the basic flow without mints and burns being set. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Added mints and burns to Erc20 flow tests

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
