### PR TITLE
Add mints and burns to testFlowERC1155FlowERC20ToERC20

### DIFF
--- a/test/concrete/flowErc1155/FlowExpressionTest.sol
+++ b/test/concrete/flowErc1155/FlowExpressionTest.sol
@@ -11,11 +11,13 @@ import {SignContextLib} from "test/lib/SignContextLib.sol";
 import {LibContextWrapper} from "test/lib/LibContextWrapper.sol";
 import {FlowERC1155Test} from "../../abstract/FlowERC1155Test.sol";
 import {FlowERC1155IOV1} from "src/interface/unstable/IFlowERC1155V5.sol";
+import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
 
 contract FlowExpressionTest is FlowERC1155Test {
     using SignContextLib for Vm;
     using LibUint256Matrix for uint256[];
     using LibContextWrapper for uint256[][];
+    using Address for address;
 
     /**
      * @dev Tests that the addresses of expressions emitted in the event
@@ -45,18 +47,30 @@ contract FlowExpressionTest is FlowERC1155Test {
         uint256 fuzzedKeyAlice,
         uint256[] memory fuzzedcallerContext0,
         uint256[] memory fuzzedcallerContext1,
-        string memory uri
+        string memory uri,
+        uint256 id,
+        uint256 amount,
+        address alice
     ) public {
+        vm.assume(!alice.isContract());
+        vm.assume(alice != address(0));
+
         uint256[][] memory matrixCallerContext =
             fuzzedcallerContext0.matrixFrom(fuzzedcallerContext1, fuzzedcallerContext0);
 
         (IFlowERC1155V5 flowErc1155, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
 
         {
+            ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
+            mints[0] = ERC1155SupplyChange({account: alice, id: id, amount: amount});
+
+            ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
+            burns[0] = ERC1155SupplyChange({account: alice, id: id, amount: amount});
+
             uint256[] memory stack = generateFlowStack(
                 FlowERC1155IOV1(
-                    new ERC1155SupplyChange[](0),
-                    new ERC1155SupplyChange[](0),
+                    mints,
+                    burns,
                     FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
                 )
             );

--- a/test/concrete/flowErc1155/FlowMulticallTest.sol
+++ b/test/concrete/flowErc1155/FlowMulticallTest.sol
@@ -14,9 +14,11 @@ import {FlowERC1155Test} from "../../abstract/FlowERC1155Test.sol";
 import {
     IFlowERC1155V5, ERC1155SupplyChange, FlowERC1155IOV1
 } from "../../../src/interface/unstable/IFlowERC1155V5.sol";
+import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
 
 contract FlowMulticallTest is FlowERC1155Test {
     using LibUint256Matrix for uint256[];
+    using Address for address;
 
     /// Should call multiple flows from same flow contract at once using multicall
     function testFlowErc1155MulticallFlows(
@@ -31,6 +33,7 @@ contract FlowMulticallTest is FlowERC1155Test {
         vm.assume(sentinel != tokenId);
         vm.assume(sentinel != amount);
         vm.assume(bob != address(0));
+        vm.assume(!bob.isContract());
 
         vm.label(bob, "Bob");
         vm.label(expressionA, "expressionA");

--- a/test/concrete/flowErc1155/FlowMulticallTest.sol
+++ b/test/concrete/flowErc1155/FlowMulticallTest.sol
@@ -30,6 +30,7 @@ contract FlowMulticallTest is FlowERC1155Test {
         vm.assume(expressionA != expressionB);
         vm.assume(sentinel != tokenId);
         vm.assume(sentinel != amount);
+        vm.assume(bob != address(0));
 
         vm.label(bob, "Bob");
         vm.label(expressionA, "expressionA");
@@ -55,12 +56,14 @@ contract FlowMulticallTest is FlowERC1155Test {
             erc20Transfers[0] =
                 ERC20Transfer({token: address(iTokenB), from: bob, to: address(flowErc1155), amount: amount});
 
+            ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
+            mints[0] = ERC1155SupplyChange({account: bob, id: tokenId, amount: amount});
+
+            ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
+            burns[0] = ERC1155SupplyChange({account: bob, id: tokenId, amount: amount});
+
             uint256[] memory stack = generateFlowStack(
-                FlowERC1155IOV1(
-                    new ERC1155SupplyChange[](0),
-                    new ERC1155SupplyChange[](0),
-                    FlowTransferV1(erc20Transfers, erc721Transfers, new ERC1155Transfer[](0))
-                )
+                FlowERC1155IOV1(mints, burns, FlowTransferV1(erc20Transfers, erc721Transfers, new ERC1155Transfer[](0)))
             );
 
             interpreterEval2MockCall(
@@ -101,12 +104,14 @@ contract FlowMulticallTest is FlowERC1155Test {
             erc721Transfers[0] =
                 ERC721Transfer({token: address(iTokenA), from: bob, to: address(flowErc1155), id: tokenId});
 
+            ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
+            mints[0] = ERC1155SupplyChange({account: bob, id: tokenId, amount: amount});
+
+            ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
+            burns[0] = ERC1155SupplyChange({account: bob, id: tokenId, amount: amount});
+
             uint256[] memory stack = generateFlowStack(
-                FlowERC1155IOV1(
-                    new ERC1155SupplyChange[](0),
-                    new ERC1155SupplyChange[](0),
-                    FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, erc1155Transfers)
-                )
+                FlowERC1155IOV1(mints, burns, FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, erc1155Transfers))
             );
 
             interpreterEval2MockCall(

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -188,11 +188,15 @@ contract Erc1155FlowTest is FlowERC1155Test {
             )
         );
 
+        ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
+        mints[0] = ERC1155SupplyChange({account: alice, id: erc1155BInTokenId, amount: erc1155BInAmmount});
+
+        ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
+        burns[0] = ERC1155SupplyChange({account: alice, id: erc1155BInTokenId, amount: 0 ether});
+
         uint256[] memory stack = generateFlowStack(
             FlowERC1155IOV1(
-                new ERC1155SupplyChange[](0),
-                new ERC1155SupplyChange[](0),
-                FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), erc1155Transfers)
+                mints, burns, FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), erc1155Transfers)
             )
         );
         interpreterEval2MockCall(stack, new uint256[](0));
@@ -236,6 +240,11 @@ contract Erc1155FlowTest is FlowERC1155Test {
                 bytes4(keccak256("safeTransferFrom(address,address,uint256)")), erc1155Flow, alice, erc721OutTokenId
             )
         );
+        ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
+        mints[0] = ERC1155SupplyChange({account: alice, id: erc721OutTokenId, amount: erc20InAmount});
+
+        ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
+        burns[0] = ERC1155SupplyChange({account: alice, id: erc721OutTokenId, amount: 0 ether});
 
         uint256[] memory stack = generateFlowStack(
             FlowERC1155IOV1(

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -4,16 +4,16 @@ pragma solidity =0.8.19;
 import {Test, Vm} from "forge-std/Test.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {IERC20Upgradeable as IERC20} from
-"openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
+    "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
 import {IERC1155Upgradeable as IERC1155} from
-"openzeppelin-contracts-upgradeable/contracts/token/ERC1155/IERC1155Upgradeable.sol";
+    "openzeppelin-contracts-upgradeable/contracts/token/ERC1155/IERC1155Upgradeable.sol";
 import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {LibEvaluable} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {IInterpreterV2, DEFAULT_STATE_NAMESPACE} from "rain.interpreter.interface/interface/IInterpreterV2.sol";
 import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpreterStoreV2.sol";
 import {FlowTransferV1, ERC20Transfer, ERC721Transfer, ERC1155Transfer} from "src/interface/unstable/IFlowV5.sol";
 import {
-IFlowERC1155V5, ERC1155SupplyChange, FlowERC1155IOV1
+    IFlowERC1155V5, ERC1155SupplyChange, FlowERC1155IOV1
 } from "../../../src/interface/unstable/IFlowERC1155V5.sol";
 import {FlowERC1155Test} from "test/abstract/FlowERC1155Test.sol";
 import {IFlowERC1155V5} from "../../../src/interface/unstable/IFlowERC1155V5.sol";
@@ -42,9 +42,9 @@ contract Erc1155FlowTest is FlowERC1155Test {
 
         ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](2);
         erc20Transfers[0] =
-                        ERC20Transfer({token: address(iTokenA), from: address(erc1155Flow), to: alice, amount: erc20OutAmmount});
+            ERC20Transfer({token: address(iTokenA), from: address(erc1155Flow), to: alice, amount: erc20OutAmmount});
         erc20Transfers[1] =
-                        ERC20Transfer({token: address(iTokenB), from: alice, to: address(erc1155Flow), amount: erc20BInAmmount});
+            ERC20Transfer({token: address(iTokenB), from: alice, to: address(erc1155Flow), amount: erc20BInAmmount});
 
         vm.startPrank(alice);
 
@@ -60,13 +60,11 @@ contract Erc1155FlowTest is FlowERC1155Test {
         mints[0] = ERC1155SupplyChange({account: alice, id: id, amount: erc20BInAmmount});
 
         ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
-        burns[0] = ERC1155SupplyChange({account: alice,  id: id, amount: 0 ether});
+        burns[0] = ERC1155SupplyChange({account: alice, id: id, amount: 0 ether});
 
         uint256[] memory stack = generateFlowStack(
             FlowERC1155IOV1(
-                mints,
-                burns,
-                FlowTransferV1(erc20Transfers, new ERC721Transfer[](0), new ERC1155Transfer[](0))
+                mints, burns, FlowTransferV1(erc20Transfers, new ERC721Transfer[](0), new ERC1155Transfer[](0))
             )
         );
 
@@ -84,7 +82,8 @@ contract Erc1155FlowTest is FlowERC1155Test {
         uint256 fuzzedKeyAlice,
         uint256 erc721OutTokenId,
         uint256 erc721BInTokenId,
-        string memory uri
+        string memory uri,
+        uint256 amount
     ) external {
         // Ensure the fuzzed key is within the valid range for secp256k1
         uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
@@ -98,9 +97,9 @@ contract Erc1155FlowTest is FlowERC1155Test {
 
         ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](2);
         erc721Transfers[0] =
-                        ERC721Transfer({token: address(iTokenA), from: address(erc1155Flow), to: alice, id: erc721OutTokenId});
+            ERC721Transfer({token: address(iTokenA), from: address(erc1155Flow), to: alice, id: erc721OutTokenId});
         erc721Transfers[1] =
-                        ERC721Transfer({token: address(iTokenB), from: alice, to: address(erc1155Flow), id: erc721BInTokenId});
+            ERC721Transfer({token: address(iTokenB), from: alice, to: address(erc1155Flow), id: erc721BInTokenId});
 
         vm.mockCall(iTokenA, abi.encodeWithSelector(bytes4(keccak256("safeTransferFrom(address,address,uint256)"))), "");
         vm.expectCall(
@@ -117,12 +116,15 @@ contract Erc1155FlowTest is FlowERC1155Test {
                 bytes4(keccak256("safeTransferFrom(address,address,uint256)")), alice, erc1155Flow, erc721BInTokenId
             )
         );
+        ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
+        mints[0] = ERC1155SupplyChange({account: alice, id: erc721BInTokenId, amount: amount});
+
+        ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
+        burns[0] = ERC1155SupplyChange({account: alice, id: erc721BInTokenId, amount: 0 ether});
 
         uint256[] memory stack = generateFlowStack(
             FlowERC1155IOV1(
-                new ERC1155SupplyChange[](0),
-                new ERC1155SupplyChange[](0),
-                FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, new ERC1155Transfer[](0))
+                mints, burns, FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, new ERC1155Transfer[](0))
             )
         );
         interpreterEval2MockCall(stack, new uint256[](0));
@@ -218,11 +220,11 @@ contract Erc1155FlowTest is FlowERC1155Test {
 
         ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](1);
         erc20Transfers[0] =
-                        ERC20Transfer({token: address(iTokenA), from: alice, to: address(erc1155Flow), amount: erc20InAmount});
+            ERC20Transfer({token: address(iTokenA), from: alice, to: address(erc1155Flow), amount: erc20InAmount});
 
         ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](1);
         erc721Transfers[0] =
-                        ERC721Transfer({token: iTokenB, from: address(erc1155Flow), to: alice, id: erc721OutTokenId});
+            ERC721Transfer({token: iTokenB, from: address(erc1155Flow), to: alice, id: erc721OutTokenId});
 
         vm.mockCall(iTokenA, abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));
         vm.expectCall(iTokenA, abi.encodeWithSelector(IERC20.transferFrom.selector, alice, erc1155Flow, erc20InAmount));
@@ -269,7 +271,7 @@ contract Erc1155FlowTest is FlowERC1155Test {
         expressions[0] = expressionA;
 
         (IFlowERC1155V5 flowErc1155, EvaluableV2[] memory evaluables) =
-                        deployIFlowERC1155V5(expressions, expressionB, new uint256[][](1), uri);
+            deployIFlowERC1155V5(expressions, expressionB, new uint256[][](1), uri);
         assumeEtchable(alice, address(flowErc1155));
 
         {

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -4,16 +4,16 @@ pragma solidity =0.8.19;
 import {Test, Vm} from "forge-std/Test.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {IERC20Upgradeable as IERC20} from
-    "openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
+"openzeppelin-contracts-upgradeable/contracts/token/ERC20/IERC20Upgradeable.sol";
 import {IERC1155Upgradeable as IERC1155} from
-    "openzeppelin-contracts-upgradeable/contracts/token/ERC1155/IERC1155Upgradeable.sol";
+"openzeppelin-contracts-upgradeable/contracts/token/ERC1155/IERC1155Upgradeable.sol";
 import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {LibEvaluable} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {IInterpreterV2, DEFAULT_STATE_NAMESPACE} from "rain.interpreter.interface/interface/IInterpreterV2.sol";
 import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpreterStoreV2.sol";
 import {FlowTransferV1, ERC20Transfer, ERC721Transfer, ERC1155Transfer} from "src/interface/unstable/IFlowV5.sol";
 import {
-    IFlowERC1155V5, ERC1155SupplyChange, FlowERC1155IOV1
+IFlowERC1155V5, ERC1155SupplyChange, FlowERC1155IOV1
 } from "../../../src/interface/unstable/IFlowERC1155V5.sol";
 import {FlowERC1155Test} from "test/abstract/FlowERC1155Test.sol";
 import {IFlowERC1155V5} from "../../../src/interface/unstable/IFlowERC1155V5.sol";
@@ -23,82 +23,12 @@ contract Erc1155FlowTest is FlowERC1155Test {
     using LibEvaluable for EvaluableV2;
     using SignContextLib for Vm;
 
-    /// Tests the flow between ERC721 and ERC1155 on the good path.
-    function testFlowERC1155FlowERC721ToERC1155(
-        address alice,
-        uint256 erc721InTokenId,
-        uint256 erc1155OutTokenId,
-        uint256 erc1155OutAmmount,
-        string memory uri,
-        uint256 id
-    ) external {
-        vm.assume(sentinel != erc721InTokenId);
-        vm.assume(sentinel != erc1155OutTokenId);
-        vm.assume(sentinel != erc1155OutAmmount);
-        vm.assume(address(0) != alice);
-
-        vm.label(alice, "Alice");
-
-        (IFlowERC1155V5 flowErc1155, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
-
-        assumeEtchable(alice, address(flowErc1155));
-
-        {
-            ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](1);
-            erc721Transfers[0] =
-                ERC721Transfer({token: address(iTokenA), from: alice, to: address(flowErc1155), id: erc721InTokenId});
-
-            ERC1155Transfer[] memory erc1155Transfers = new ERC1155Transfer[](1);
-            erc1155Transfers[0] = ERC1155Transfer({
-                token: address(iTokenB),
-                from: address(flowErc1155),
-                to: alice,
-                id: erc1155OutTokenId,
-                amount: erc1155OutAmmount
-            });
-
-            ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
-            mints[0] = ERC1155SupplyChange({account: alice, id: id, amount: 20 ether});
-
-            ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
-            burns[0] = ERC1155SupplyChange({account: alice, id: id, amount: 10 ether});
-
-            uint256[] memory stack = generateFlowStack(
-                FlowERC1155IOV1(mints, burns, FlowTransferV1(new ERC20Transfer[](0), erc721Transfers, erc1155Transfers))
-            );
-            interpreterEval2MockCall(stack, new uint256[](0));
-        }
-
-        {
-            vm.mockCall(iTokenB, abi.encodeWithSelector(IERC1155.safeTransferFrom.selector), "");
-            vm.expectCall(
-                iTokenB,
-                abi.encodeWithSelector(
-                    IERC1155.safeTransferFrom.selector, flowErc1155, alice, erc1155OutTokenId, erc1155OutAmmount, ""
-                )
-            );
-
-            vm.mockCall(
-                iTokenA, abi.encodeWithSelector(bytes4(keccak256("safeTransferFrom(address,address,uint256)"))), ""
-            );
-            vm.expectCall(
-                iTokenA,
-                abi.encodeWithSelector(
-                    bytes4(keccak256("safeTransferFrom(address,address,uint256)")), alice, flowErc1155, erc721InTokenId
-                )
-            );
-        }
-
-        vm.startPrank(alice);
-        flowErc1155.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
-        vm.stopPrank();
-    }
-
     function testFlowERC1155FlowERC20ToERC20(
         uint256 erc20OutAmmount,
         uint256 erc20BInAmmount,
         string memory uri,
-        uint256 fuzzedKeyAlice
+        uint256 fuzzedKeyAlice,
+        uint256 id
     ) external {
         vm.assume(sentinel != erc20OutAmmount);
         vm.assume(sentinel != erc20BInAmmount);
@@ -112,9 +42,9 @@ contract Erc1155FlowTest is FlowERC1155Test {
 
         ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](2);
         erc20Transfers[0] =
-            ERC20Transfer({token: address(iTokenA), from: address(erc1155Flow), to: alice, amount: erc20OutAmmount});
+                        ERC20Transfer({token: address(iTokenA), from: address(erc1155Flow), to: alice, amount: erc20OutAmmount});
         erc20Transfers[1] =
-            ERC20Transfer({token: address(iTokenB), from: alice, to: address(erc1155Flow), amount: erc20BInAmmount});
+                        ERC20Transfer({token: address(iTokenB), from: alice, to: address(erc1155Flow), amount: erc20BInAmmount});
 
         vm.startPrank(alice);
 
@@ -126,10 +56,16 @@ contract Erc1155FlowTest is FlowERC1155Test {
             address(iTokenB), abi.encodeWithSelector(IERC20.transferFrom.selector, alice, erc1155Flow, erc20BInAmmount)
         );
 
+        ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
+        mints[0] = ERC1155SupplyChange({account: alice, id: id, amount: erc20BInAmmount});
+
+        ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
+        burns[0] = ERC1155SupplyChange({account: alice,  id: id, amount: 0 ether});
+
         uint256[] memory stack = generateFlowStack(
             FlowERC1155IOV1(
-                new ERC1155SupplyChange[](0),
-                new ERC1155SupplyChange[](0),
+                mints,
+                burns,
                 FlowTransferV1(erc20Transfers, new ERC721Transfer[](0), new ERC1155Transfer[](0))
             )
         );
@@ -162,9 +98,9 @@ contract Erc1155FlowTest is FlowERC1155Test {
 
         ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](2);
         erc721Transfers[0] =
-            ERC721Transfer({token: address(iTokenA), from: address(erc1155Flow), to: alice, id: erc721OutTokenId});
+                        ERC721Transfer({token: address(iTokenA), from: address(erc1155Flow), to: alice, id: erc721OutTokenId});
         erc721Transfers[1] =
-            ERC721Transfer({token: address(iTokenB), from: alice, to: address(erc1155Flow), id: erc721BInTokenId});
+                        ERC721Transfer({token: address(iTokenB), from: alice, to: address(erc1155Flow), id: erc721BInTokenId});
 
         vm.mockCall(iTokenA, abi.encodeWithSelector(bytes4(keccak256("safeTransferFrom(address,address,uint256)"))), "");
         vm.expectCall(
@@ -282,11 +218,11 @@ contract Erc1155FlowTest is FlowERC1155Test {
 
         ERC20Transfer[] memory erc20Transfers = new ERC20Transfer[](1);
         erc20Transfers[0] =
-            ERC20Transfer({token: address(iTokenA), from: alice, to: address(erc1155Flow), amount: erc20InAmount});
+                        ERC20Transfer({token: address(iTokenA), from: alice, to: address(erc1155Flow), amount: erc20InAmount});
 
         ERC721Transfer[] memory erc721Transfers = new ERC721Transfer[](1);
         erc721Transfers[0] =
-            ERC721Transfer({token: iTokenB, from: address(erc1155Flow), to: alice, id: erc721OutTokenId});
+                        ERC721Transfer({token: iTokenB, from: address(erc1155Flow), to: alice, id: erc721OutTokenId});
 
         vm.mockCall(iTokenA, abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));
         vm.expectCall(iTokenA, abi.encodeWithSelector(IERC20.transferFrom.selector, alice, erc1155Flow, erc20InAmount));
@@ -333,7 +269,7 @@ contract Erc1155FlowTest is FlowERC1155Test {
         expressions[0] = expressionA;
 
         (IFlowERC1155V5 flowErc1155, EvaluableV2[] memory evaluables) =
-            deployIFlowERC1155V5(expressions, expressionB, new uint256[][](1), uri);
+                        deployIFlowERC1155V5(expressions, expressionB, new uint256[][](1), uri);
         assumeEtchable(alice, address(flowErc1155));
 
         {

--- a/test/concrete/flowErc1155/FlowTimeTest.sol
+++ b/test/concrete/flowErc1155/FlowTimeTest.sol
@@ -13,20 +13,31 @@ import {FlowERC1155Test} from "../../abstract/FlowERC1155Test.sol";
 import {SignContextLib} from "test/lib/SignContextLib.sol";
 import {DEFAULT_STATE_NAMESPACE} from "rain.interpreter.interface/interface/IInterpreterV2.sol";
 import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpreterStoreV2.sol";
+import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
 
 contract FlowTimeTest is FlowUtilsAbstractTest, FlowERC1155Test {
     using SignContextLib for Vm;
+    using Address for address;
 
-    function testFlowTime(string memory uri, uint256[] memory writeToStore) public {
+    function testFlowTime(string memory uri, uint256[] memory writeToStore, uint256 id, uint256 amount, address alice)
+        public
+    {
+        vm.assume(alice != address(0));
+        vm.assume(amount != 0);
         vm.assume(writeToStore.length != 0);
+        vm.assume(!alice.isContract());
 
         (IFlowERC1155V5 erc1155Flow, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
 
+        ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](1);
+        mints[0] = ERC1155SupplyChange({account: alice, id: id, amount: amount});
+
+        ERC1155SupplyChange[] memory burns = new ERC1155SupplyChange[](1);
+        burns[0] = ERC1155SupplyChange({account: alice, id: id, amount: amount});
+
         uint256[] memory stack = generateFlowStack(
             FlowERC1155IOV1(
-                new ERC1155SupplyChange[](0),
-                new ERC1155SupplyChange[](0),
-                FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
+                mints, burns, FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
             )
         );
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

In erc1155 flow test, minting and burning were empty. Essentially, that was re-testing the basic flow without mints and burns being set.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Added mints and burns to Erc20 flow tests

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
