### PR TITLE
Add mints and burns to testFlowERC721ShouldValidateContextFromEvent

### DIFF
--- a/test/concrete/flowErc721/FlowExpressionTest.sol
+++ b/test/concrete/flowErc721/FlowExpressionTest.sol
@@ -50,18 +50,26 @@ contract FlowExpressionTest is FlowERC721Test {
         uint256[] memory fuzzedcallerContext1,
         string memory name,
         string memory symbol,
-        string memory uri
+        string memory uri,
+        address alice,
+        uint256 id
     ) public {
+        vm.assume(alice != address(0));
         uint256[][] memory matrixCallerContext =
             fuzzedcallerContext0.matrixFrom(fuzzedcallerContext1, fuzzedcallerContext0);
 
         (IFlowERC721V5 flowErc721, EvaluableV2 memory evaluable) = deployFlowERC721(name, symbol, uri);
-
         {
+            ERC721SupplyChange[] memory mints = new ERC721SupplyChange[](1);
+            mints[0] = ERC721SupplyChange({account: alice, id: id});
+
+            ERC721SupplyChange[] memory burns = new ERC721SupplyChange[](1);
+            burns[0] = ERC721SupplyChange({account: alice, id: id});
+
             uint256[] memory stack = generateFlowStack(
                 FlowERC721IOV1(
-                    new ERC721SupplyChange[](0),
-                    new ERC721SupplyChange[](0),
+                    mints,
+                    burns,
                     FlowTransferV1(new ERC20Transfer[](0), new ERC721Transfer[](0), new ERC1155Transfer[](0))
                 )
             );


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
In erc721 flow test, minting and burning were empty. Essentially, that was re-testing the basic flow without mints and burns being set.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Added mints and burns to Erc721 flow tests

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
