### PR TITLE
FlowUtilsAbstractTest has been split into two libraries: LibLogHelper…

### DIFF
--- a/test/abstract/FlowBasicTest.sol
+++ b/test/abstract/FlowBasicTest.sol
@@ -11,9 +11,16 @@ import {STUB_EXPRESSION_BYTECODE, REVERTING_MOCK_BYTECODE} from "./TestConstants
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {CloneFactory} from "rain.factory/src/concrete/CloneFactory.sol";
 import {LibUint256Matrix} from "rain.solmem/lib/LibUint256Matrix.sol";
+import {LibLogHelper} from "test/lib/LibLogHelper.sol";
+import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
+import {LibStackGeneration} from "test/lib/LibStackGeneration.sol";
+import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
 
 abstract contract FlowBasicTest is FlowUtilsAbstractTest, InterpreterMockTest {
     using LibUint256Matrix for uint256[];
+    using LibLogHelper for Vm.Log[];
+    using LibStackGeneration for uint256;
+    using Address for address;
 
     CloneFactory internal immutable iCloneFactory;
     IFlowV5 internal immutable iFlowImplementation;
@@ -114,6 +121,7 @@ abstract contract FlowBasicTest is FlowUtilsAbstractTest, InterpreterMockTest {
         vm.assume(account != address(vm));
         vm.assume(sentinel != uint256(uint160(account)));
         vm.assume(account != address(expression));
+        vm.assume(!account.isContract());
         // The console.
         vm.assume(account != address(0x000000000000000000636F6e736F6c652e6c6f67));
     }

--- a/test/abstract/FlowUtilsAbstractTest.sol
+++ b/test/abstract/FlowUtilsAbstractTest.sol
@@ -47,7 +47,7 @@ abstract contract FlowUtilsAbstractTest is Test {
     function findEvent(Vm.Log[] memory logs, bytes32 eventSignature) internal pure returns (Vm.Log memory) {
         return logs.findEvent(eventSignature);
     }
-    
+
     // A temporary solution for a smooth transition to using libraries.
     function findEvents(Vm.Log[] memory logs, bytes32 eventSignature)
         internal

--- a/test/abstract/FlowUtilsAbstractTest.sol
+++ b/test/abstract/FlowUtilsAbstractTest.sol
@@ -8,8 +8,13 @@ import {Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
 import {FlowERC1155IOV1} from "src/interface/unstable/IFlowERC1155V5.sol";
 import {FlowERC721IOV1} from "src/interface/unstable/IFlowERC721V5.sol";
 import {FlowERC20IOV1} from "src/interface/unstable/IFlowERC20V5.sol";
+import {LibStackGeneration} from "test/lib/LibStackGeneration.sol";
+import {LibLogHelper} from "test/lib/LibLogHelper.sol";
 
 abstract contract FlowUtilsAbstractTest is Test {
+    using LibStackGeneration for uint256;
+    using LibLogHelper for Vm.Log[];
+
     uint256 internal immutable sentinel;
 
     constructor() {
@@ -18,143 +23,37 @@ abstract contract FlowUtilsAbstractTest is Test {
         vm.resumeGasMetering();
     }
 
+    // A temporary solution for a smooth transition to using libraries.
     function generateFlowStack(FlowTransferV1 memory flowTransfer) internal view returns (uint256[] memory stack) {
-        uint256 totalItems = 1 + (flowTransfer.erc1155.length * 5) + 1 + (flowTransfer.erc721.length * 4) + 1
-            + (flowTransfer.erc20.length * 4);
-        stack = new uint256[](totalItems);
-        uint256 index = 0;
-
-        stack[index++] = sentinel;
-        for (uint256 i = 0; i < flowTransfer.erc1155.length; i++) {
-            stack[index++] = uint256(uint160(flowTransfer.erc1155[i].token));
-            stack[index++] = uint256(uint160(flowTransfer.erc1155[i].from));
-            stack[index++] = uint256(uint160(flowTransfer.erc1155[i].to));
-            stack[index++] = flowTransfer.erc1155[i].id;
-            stack[index++] = flowTransfer.erc1155[i].amount;
-        }
-
-        stack[index++] = sentinel;
-        for (uint256 i = 0; i < flowTransfer.erc721.length; i++) {
-            stack[index++] = uint256(uint160(flowTransfer.erc721[i].token));
-            stack[index++] = uint256(uint160(flowTransfer.erc721[i].from));
-            stack[index++] = uint256(uint160(flowTransfer.erc721[i].to));
-            stack[index++] = flowTransfer.erc721[i].id;
-        }
-
-        stack[index++] = sentinel;
-        for (uint256 i = 0; i < flowTransfer.erc20.length; i++) {
-            stack[index++] = uint256(uint160(flowTransfer.erc20[i].token));
-            stack[index++] = uint256(uint160(flowTransfer.erc20[i].from));
-            stack[index++] = uint256(uint160(flowTransfer.erc20[i].to));
-            stack[index++] = flowTransfer.erc20[i].amount;
-        }
-
-        return stack;
+        stack = sentinel.generateFlowStack(flowTransfer);
     }
 
+    // A temporary solution for a smooth transition to using libraries.
     function generateFlowStack(FlowERC1155IOV1 memory flowERC1155IO) internal view returns (uint256[] memory stack) {
-        uint256[] memory transfersStack = generateFlowStack(flowERC1155IO.flow);
-        uint256 totalItems =
-            transfersStack.length + 1 + (flowERC1155IO.burns.length * 3) + 1 + (flowERC1155IO.mints.length * 3);
-
-        stack = new uint256[](totalItems);
-        uint256 index = 0;
-        uint256 separator = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
-
-        for (uint256 i = 0; i < transfersStack.length; i++) {
-            stack[index++] = transfersStack[i];
-        }
-
-        stack[index++] = separator;
-        for (uint256 i = 0; i < flowERC1155IO.burns.length; i++) {
-            stack[index++] = uint256(uint160(flowERC1155IO.burns[i].account));
-            stack[index++] = flowERC1155IO.burns[i].id;
-            stack[index++] = flowERC1155IO.burns[i].amount;
-        }
-
-        stack[index++] = separator;
-        for (uint256 i = 0; i < flowERC1155IO.mints.length; i++) {
-            stack[index++] = uint256(uint160(flowERC1155IO.mints[i].account));
-            stack[index++] = flowERC1155IO.mints[i].id;
-            stack[index++] = flowERC1155IO.mints[i].amount;
-        }
+        stack = sentinel.generateFlowStack(flowERC1155IO);
     }
 
+    // A temporary solution for a smooth transition to using libraries.
     function generateFlowStack(FlowERC721IOV1 memory flowERC721IO) internal view returns (uint256[] memory stack) {
-        uint256[] memory transfersStack = generateFlowStack(flowERC721IO.flow);
-        uint256 totalItems =
-            transfersStack.length + 1 + (flowERC721IO.burns.length * 2) + 1 + (flowERC721IO.mints.length * 2);
-
-        stack = new uint256[](totalItems);
-        uint256 index = 0;
-        uint256 separator = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
-
-        for (uint256 i = 0; i < transfersStack.length; i++) {
-            stack[index++] = transfersStack[i];
-        }
-
-        stack[index++] = separator;
-        for (uint256 i = 0; i < flowERC721IO.burns.length; i++) {
-            stack[index++] = uint256(uint160(flowERC721IO.burns[i].account));
-            stack[index++] = flowERC721IO.burns[i].id;
-        }
-
-        stack[index++] = separator;
-        for (uint256 i = 0; i < flowERC721IO.mints.length; i++) {
-            stack[index++] = uint256(uint160(flowERC721IO.mints[i].account));
-            stack[index++] = flowERC721IO.mints[i].id;
-        }
+        stack = sentinel.generateFlowStack(flowERC721IO);
     }
 
+    // A temporary solution for a smooth transition to using libraries.
     function generateFlowStack(FlowERC20IOV1 memory flowERC20IO) internal view returns (uint256[] memory stack) {
-        uint256[] memory transfersStack = generateFlowStack(flowERC20IO.flow);
-        uint256 totalItems =
-            transfersStack.length + 1 + (flowERC20IO.burns.length * 2) + 1 + (flowERC20IO.mints.length * 2);
-
-        stack = new uint256[](totalItems);
-        uint256 index = 0;
-        uint256 separator = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
-
-        for (uint256 i = 0; i < transfersStack.length; i++) {
-            stack[index++] = transfersStack[i];
-        }
-
-        stack[index++] = separator;
-        for (uint256 i = 0; i < flowERC20IO.burns.length; i++) {
-            stack[index++] = uint256(uint160(flowERC20IO.burns[i].account));
-            stack[index++] = flowERC20IO.burns[i].amount;
-        }
-
-        stack[index++] = separator;
-        for (uint256 i = 0; i < flowERC20IO.mints.length; i++) {
-            stack[index++] = uint256(uint160(flowERC20IO.mints[i].account));
-            stack[index++] = flowERC20IO.mints[i].amount;
-        }
+        stack = sentinel.generateFlowStack(flowERC20IO);
     }
 
+    // A temporary solution for a smooth transition to using libraries.
     function findEvent(Vm.Log[] memory logs, bytes32 eventSignature) internal pure returns (Vm.Log memory) {
-        Vm.Log[] memory foundLogs = findEvents(logs, eventSignature);
-        require(foundLogs.length >= 1, "Event not found!");
-        return (foundLogs[0]);
+        return logs.findEvent(eventSignature);
     }
-
+    
+    // A temporary solution for a smooth transition to using libraries.
     function findEvents(Vm.Log[] memory logs, bytes32 eventSignature)
         internal
         pure
         returns (Vm.Log[] memory foundLogs)
     {
-        foundLogs = new Vm.Log[](logs.length);
-        uint256 foundCount = 0;
-
-        for (uint256 i = 0; i < logs.length; i++) {
-            if (logs[i].topics[0] == eventSignature) {
-                foundLogs[foundCount] = logs[i];
-                foundCount++;
-            }
-        }
-
-        assembly ("memory-safe") {
-            mstore(foundLogs, foundCount)
-        }
+        foundLogs = logs.findEvents(eventSignature);
     }
 }

--- a/test/lib/LibLogHelper.sol
+++ b/test/lib/LibLogHelper.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: CAL
+pragma solidity =0.8.19;
+
+import {Vm} from "forge-std/Test.sol";
+
+library LibLogHelper {
+    /// @dev Finds the first log with the specified event signature in the logs array.
+    /// @param logs The array of logs to search through.
+    /// @param eventSignature The event signature to find.
+    /// @return foundLogs first log that matches the event signature.
+    function findEvent(Vm.Log[] memory logs, bytes32 eventSignature) internal pure returns (Vm.Log memory) {
+        Vm.Log[] memory foundLogs = findEvents(logs, eventSignature);
+        require(foundLogs.length >= 1, "Event not found!");
+        return (foundLogs[0]);
+    }
+
+    /// @dev Finds all logs with the specified event signature in the logs array.
+    /// @param logs The array of logs to search through.
+    /// @param eventSignature The event signature to find.
+    /// @return foundLogs array of logs that match the event signature.
+    function findEvents(Vm.Log[] memory logs, bytes32 eventSignature)
+        internal
+        pure
+        returns (Vm.Log[] memory foundLogs)
+    {
+        foundLogs = new Vm.Log[](logs.length);
+        uint256 foundCount = 0;
+
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == eventSignature) {
+                foundLogs[foundCount] = logs[i];
+                foundCount++;
+            }
+        }
+
+        assembly ("memory-safe") {
+            mstore(foundLogs, foundCount)
+        }
+    }
+}

--- a/test/lib/LibStackGeneration.sol
+++ b/test/lib/LibStackGeneration.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: CAL
+pragma solidity ^0.8.18;
+
+import {Test, Vm} from "forge-std/Test.sol";
+
+import {FlowTransferV1, RAIN_FLOW_SENTINEL} from "src/interface/unstable/IFlowV5.sol";
+import {Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
+import {FlowERC1155IOV1} from "src/interface/unstable/IFlowERC1155V5.sol";
+import {FlowERC721IOV1} from "src/interface/unstable/IFlowERC721V5.sol";
+import {FlowERC20IOV1} from "src/interface/unstable/IFlowERC20V5.sol";
+
+library LibStackGeneration {
+    function generateFlowStack(uint256 sentinel, FlowTransferV1 memory flowTransfer)
+        internal
+        pure
+        returns (uint256[] memory stack)
+    {
+        uint256 totalItems = 1 + (flowTransfer.erc1155.length * 5) + 1 + (flowTransfer.erc721.length * 4) + 1
+            + (flowTransfer.erc20.length * 4);
+        stack = new uint256[](totalItems);
+        uint256 index = 0;
+
+        stack[index++] = sentinel;
+        for (uint256 i = 0; i < flowTransfer.erc1155.length; i++) {
+            stack[index++] = uint256(uint160(flowTransfer.erc1155[i].token));
+            stack[index++] = uint256(uint160(flowTransfer.erc1155[i].from));
+            stack[index++] = uint256(uint160(flowTransfer.erc1155[i].to));
+            stack[index++] = flowTransfer.erc1155[i].id;
+            stack[index++] = flowTransfer.erc1155[i].amount;
+        }
+
+        stack[index++] = sentinel;
+        for (uint256 i = 0; i < flowTransfer.erc721.length; i++) {
+            stack[index++] = uint256(uint160(flowTransfer.erc721[i].token));
+            stack[index++] = uint256(uint160(flowTransfer.erc721[i].from));
+            stack[index++] = uint256(uint160(flowTransfer.erc721[i].to));
+            stack[index++] = flowTransfer.erc721[i].id;
+        }
+
+        stack[index++] = sentinel;
+        for (uint256 i = 0; i < flowTransfer.erc20.length; i++) {
+            stack[index++] = uint256(uint160(flowTransfer.erc20[i].token));
+            stack[index++] = uint256(uint160(flowTransfer.erc20[i].from));
+            stack[index++] = uint256(uint160(flowTransfer.erc20[i].to));
+            stack[index++] = flowTransfer.erc20[i].amount;
+        }
+
+        return stack;
+    }
+
+    function generateFlowStack(uint256 sentinel, FlowERC1155IOV1 memory flowERC1155IO)
+        internal
+        pure
+        returns (uint256[] memory stack)
+    {
+        uint256[] memory transfersStack = generateFlowStack(sentinel, flowERC1155IO.flow);
+        uint256 totalItems =
+            transfersStack.length + 1 + (flowERC1155IO.burns.length * 3) + 1 + (flowERC1155IO.mints.length * 3);
+
+        stack = new uint256[](totalItems);
+        uint256 index = 0;
+        uint256 separator = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
+
+        for (uint256 i = 0; i < transfersStack.length; i++) {
+            stack[index++] = transfersStack[i];
+        }
+
+        stack[index++] = separator;
+        for (uint256 i = 0; i < flowERC1155IO.burns.length; i++) {
+            stack[index++] = uint256(uint160(flowERC1155IO.burns[i].account));
+            stack[index++] = flowERC1155IO.burns[i].id;
+            stack[index++] = flowERC1155IO.burns[i].amount;
+        }
+
+        stack[index++] = separator;
+        for (uint256 i = 0; i < flowERC1155IO.mints.length; i++) {
+            stack[index++] = uint256(uint160(flowERC1155IO.mints[i].account));
+            stack[index++] = flowERC1155IO.mints[i].id;
+            stack[index++] = flowERC1155IO.mints[i].amount;
+        }
+    }
+
+    function generateFlowStack(uint256 sentinel, FlowERC721IOV1 memory flowERC721IO)
+        internal
+        pure
+        returns (uint256[] memory stack)
+    {
+        uint256[] memory transfersStack = generateFlowStack(sentinel, flowERC721IO.flow);
+        uint256 totalItems =
+            transfersStack.length + 1 + (flowERC721IO.burns.length * 2) + 1 + (flowERC721IO.mints.length * 2);
+
+        stack = new uint256[](totalItems);
+        uint256 index = 0;
+        uint256 separator = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
+
+        for (uint256 i = 0; i < transfersStack.length; i++) {
+            stack[index++] = transfersStack[i];
+        }
+
+        stack[index++] = separator;
+        for (uint256 i = 0; i < flowERC721IO.burns.length; i++) {
+            stack[index++] = uint256(uint160(flowERC721IO.burns[i].account));
+            stack[index++] = flowERC721IO.burns[i].id;
+        }
+
+        stack[index++] = separator;
+        for (uint256 i = 0; i < flowERC721IO.mints.length; i++) {
+            stack[index++] = uint256(uint160(flowERC721IO.mints[i].account));
+            stack[index++] = flowERC721IO.mints[i].id;
+        }
+    }
+
+    function generateFlowStack(uint256 sentinel, FlowERC20IOV1 memory flowERC20IO)
+        internal
+        pure
+        returns (uint256[] memory stack)
+    {
+        uint256[] memory transfersStack = generateFlowStack(sentinel, flowERC20IO.flow);
+        uint256 totalItems =
+            transfersStack.length + 1 + (flowERC20IO.burns.length * 2) + 1 + (flowERC20IO.mints.length * 2);
+
+        stack = new uint256[](totalItems);
+        uint256 index = 0;
+        uint256 separator = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
+
+        for (uint256 i = 0; i < transfersStack.length; i++) {
+            stack[index++] = transfersStack[i];
+        }
+
+        stack[index++] = separator;
+        for (uint256 i = 0; i < flowERC20IO.burns.length; i++) {
+            stack[index++] = uint256(uint160(flowERC20IO.burns[i].account));
+            stack[index++] = flowERC20IO.burns[i].amount;
+        }
+
+        stack[index++] = separator;
+        for (uint256 i = 0; i < flowERC20IO.mints.length; i++) {
+            stack[index++] = uint256(uint160(flowERC20IO.mints[i].account));
+            stack[index++] = flowERC20IO.mints[i].amount;
+        }
+    }
+}


### PR DESCRIPTION
… and LibStackGeneration.

<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
The repetitive code in test cases complicated maintenance and understanding of the tests. There was a need to optimize the code structure for better readability and to reduce duplication.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- The StackGeneration and findEvent methods were moved to the LibLogHelper and LibStackGeneration libraries.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
