### PR TITLE
94 porting legacy tests from flowerc721flow  test case should utilize context in handle transfer entrypoint

### DIFF
--- a/test/concrete/flowErc721/FlowTest.sol
+++ b/test/concrete/flowErc721/FlowTest.sol
@@ -261,6 +261,7 @@ contract Erc721FlowTest is FlowERC721Test {
     ) external {
         vm.assume(sentinel != erc20OutAmmount);
         vm.assume(sentinel != erc20BInAmmount);
+        vm.assume(sentinel != id);
 
         // Ensure the fuzzed key is within the valid range for secp256k1
         uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;

--- a/test/concrete/flowErc721/FlowTest.sol
+++ b/test/concrete/flowErc721/FlowTest.sol
@@ -27,11 +27,15 @@ import {LibEncodedDispatch} from "rain.interpreter.interface/lib/caller/LibEncod
 import {LibUint256Array} from "rain.solmem/lib/LibUint256Array.sol";
 import {LibContextWrapper} from "test/lib/LibContextWrapper.sol";
 import {LibUint256Matrix} from "rain.solmem/lib/LibUint256Matrix.sol";
+import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpreterStoreV2.sol";
+import {DEFAULT_STATE_NAMESPACE} from "rain.interpreter.interface/interface/IInterpreterV2.sol";
+import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
 
 contract Erc721FlowTest is FlowERC721Test {
     using LibEvaluable for EvaluableV2;
     using SignContextLib for Vm;
     using LibUint256Matrix for uint256[];
+    using Address for address;
 
     /**
      * @notice Tests the support for the transferPreflight hook.
@@ -48,6 +52,7 @@ contract Erc721FlowTest is FlowERC721Test {
         vm.assume(sentinel != tokenIdB);
         vm.assume(tokenIdA != tokenIdB);
         vm.assume(expressionA != expressionB);
+        vm.assume(!alice.isContract());
 
         address[] memory expressions = new address[](1);
         expressions[0] = expressionA;


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Concert legacy tests from ".FlowERC721/flow" — test case "should utilize context in HANDLE_TRANSFER entrypoint"

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add new foundry test 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
