### PR TITLE
Add sentinel checks to erc1155 tests

### DIFF
--- a/test/concrete/flowErc1155/FlowExpressionTest.sol
+++ b/test/concrete/flowErc1155/FlowExpressionTest.sol
@@ -54,6 +54,7 @@ contract FlowExpressionTest is FlowERC1155Test {
     ) public {
         vm.assume(!alice.isContract());
         vm.assume(alice != address(0));
+        vm.assume(sentinel != amount);
 
         uint256[][] memory matrixCallerContext =
             fuzzedcallerContext0.matrixFrom(fuzzedcallerContext1, fuzzedcallerContext0);

--- a/test/concrete/flowErc1155/FlowPreviewTest.sol
+++ b/test/concrete/flowErc1155/FlowPreviewTest.sol
@@ -12,6 +12,7 @@ contract FlowPreviewTest is FlowERC1155Test {
     function testFlowERC1155PreviewEmptyFlowIO(string memory uri, address alice, uint256 amount) public {
         (IFlowERC1155V5 flow,) = deployIFlowERC1155V5({uri: uri});
         assumeEtchable(alice, address(flow));
+        vm.assume(sentinel != amount);
 
         ERC1155SupplyChange[] memory mints = new ERC1155SupplyChange[](2);
         mints[0] = ERC1155SupplyChange({account: alice, id: 1, amount: amount});

--- a/test/concrete/flowErc1155/FlowSignedContextTest.sol
+++ b/test/concrete/flowErc1155/FlowSignedContextTest.sol
@@ -27,6 +27,9 @@ contract FlowSignedContextTest is FlowUtilsAbstractTest, FlowERC1155Test {
         uint256 fuzzedKeyBob
     ) public {
         vm.assume(fuzzedKeyBob != fuzzedKeyAlice);
+        vm.assume(sentinel != amount);
+        vm.assume(sentinel != id);
+
         (IFlowERC1155V5 erc1155Flow, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
 
         // Ensure the fuzzed key is within the valid range for secp256k1
@@ -84,6 +87,9 @@ contract FlowSignedContextTest is FlowUtilsAbstractTest, FlowERC1155Test {
         uint256 amount
     ) public {
         vm.assume(fuzzedKeyBob != fuzzedKeyAlice);
+        vm.assume(sentinel != amount);
+        vm.assume(sentinel != id);
+
         (IFlowERC1155V5 erc1155Flow, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
 
         // Ensure the fuzzed key is within the valid range for secp256k1

--- a/test/concrete/flowErc1155/FlowTest.sol
+++ b/test/concrete/flowErc1155/FlowTest.sol
@@ -37,6 +37,7 @@ contract Erc1155FlowTest is FlowERC1155Test {
         vm.assume(sentinel != erc721InTokenId);
         vm.assume(sentinel != erc1155OutTokenId);
         vm.assume(sentinel != erc1155OutAmount);
+        vm.assume(sentinel != id);
         vm.assume(address(0) != alice);
         vm.assume(!alice.isContract());
 
@@ -106,6 +107,7 @@ contract Erc1155FlowTest is FlowERC1155Test {
     ) external {
         vm.assume(sentinel != erc1155OutAmount);
         vm.assume(sentinel != erc20InAmount);
+        vm.assume(sentinel != id);
 
         // Ensure the fuzzed key is within the valid range for secp256k1
         uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
@@ -165,6 +167,7 @@ contract Erc1155FlowTest is FlowERC1155Test {
 
         vm.assume(sentinel != erc721OutTokenId);
         vm.assume(sentinel != erc721InTokenId);
+        vm.assume(sentinel != amount);
 
         (IFlowERC1155V5 erc1155Flow, EvaluableV2 memory evaluable) = deployIFlowERC1155V5(uri);
         assumeEtchable(alice, address(erc1155Flow));
@@ -347,6 +350,7 @@ contract Erc1155FlowTest is FlowERC1155Test {
     ) external {
         vm.assume(alice != address(0));
         vm.assume(sentinel != amount);
+        vm.assume(sentinel != id);
         vm.assume(expressionA != expressionB);
         vm.assume(writeToStore.length != 0);
         vm.assume(!alice.isContract());

--- a/test/concrete/flowErc1155/FlowTimeTest.sol
+++ b/test/concrete/flowErc1155/FlowTimeTest.sol
@@ -24,6 +24,8 @@ contract FlowTimeTest is FlowUtilsAbstractTest, FlowERC1155Test {
     {
         vm.assume(alice != address(0));
         vm.assume(amount != 0);
+        vm.assume(sentinel != amount);
+        vm.assume(sentinel != id);
         vm.assume(writeToStore.length != 0);
         vm.assume(!alice.isContract());
 

--- a/test/concrete/flowErc721/FlowExpressionTest.sol
+++ b/test/concrete/flowErc721/FlowExpressionTest.sol
@@ -58,6 +58,7 @@ contract FlowExpressionTest is FlowERC721Test {
     ) public {
         vm.assume(alice != address(0));
         vm.assume(!alice.isContract());
+        vm.assume(sentinel != id);
 
         uint256[][] memory matrixCallerContext =
             fuzzedcallerContext0.matrixFrom(fuzzedcallerContext1, fuzzedcallerContext0);

--- a/test/concrete/flowErc721/FlowSignedContextTest.sol
+++ b/test/concrete/flowErc721/FlowSignedContextTest.sol
@@ -25,6 +25,7 @@ contract FlowSignedContextTest is FlowERC721Test {
         uint256 id
     ) public {
         vm.assume(fuzzedKeyBob != fuzzedKeyAlice);
+        vm.assume(sentinel != id);
         (IFlowERC721V5 erc721Flow, EvaluableV2 memory evaluable) =
             deployFlowERC721({name: name, symbol: symbol, baseURI: baseURI});
 
@@ -91,6 +92,7 @@ contract FlowSignedContextTest is FlowERC721Test {
         uint256 id
     ) public {
         vm.assume(fuzzedKeyBob != fuzzedKeyAlice);
+        vm.assume(sentinel != id);
         (IFlowERC721V5 erc721Flow, EvaluableV2 memory evaluable) =
             deployFlowERC721({name: name, symbol: symbol, baseURI: baseURI});
 

--- a/test/concrete/flowErc721/FlowTest.sol
+++ b/test/concrete/flowErc721/FlowTest.sol
@@ -322,6 +322,7 @@ contract Erc721FlowTest is FlowERC721Test {
 
         vm.assume(sentinel != erc721OutTokenId);
         vm.assume(sentinel != erc721InTokenId);
+        vm.assume(sentinel != id);
 
         (IFlowERC721V5 erc721Flow, EvaluableV2 memory evaluable) =
             deployFlowERC721({name: "FlowErc721", symbol: "FErc721", baseURI: baseURI});
@@ -379,6 +380,7 @@ contract Erc721FlowTest is FlowERC721Test {
         vm.assume(alice != address(0));
         vm.assume(expressionA != expressionB);
         vm.assume(writeToStore.length != 0);
+        vm.assume(sentinel != tokenId);
 
         address[] memory expressions = new address[](1);
         expressions[0] = expressionA;

--- a/test/concrete/flowErc721/FlowTimeTest.sol
+++ b/test/concrete/flowErc721/FlowTimeTest.sol
@@ -25,6 +25,7 @@ contract FlowTimeTest is FlowERC721Test {
     ) public {
         vm.assume(writeToStore.length != 0);
         vm.assume(alice != address(0));
+        vm.assume(sentinel != id);
         vm.assume(!alice.isContract());
 
         (IFlowERC721V5 erc1155Flow, EvaluableV2 memory evaluable) = deployFlowERC721(name, symbol, uri);


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Make sure that assume excludes the possibility of incoming parameters matching with sentinel. Right now, this test occasionally fails depending on the behavior of the fuzzer.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add assume checks to tests
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
