### PR TITLE
Add test testFlowConstructionBadCallerMetaERC721

### DIFF
--- a/test/concrete/flowErc721/FlowConstructionInitializeTest.sol
+++ b/test/concrete/flowErc721/FlowConstructionInitializeTest.sol
@@ -7,7 +7,6 @@ import {FlowERC721ConfigV2} from "src/interface/unstable/IFlowERC721V5.sol";
 import {EvaluableConfigV3} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {IExpressionDeployerV3} from "rain.interpreter.interface/interface/IExpressionDeployerV3.sol";
 import {FlowERC721Test} from "test/abstract/FlowERC721Test.sol";
-import {InsufficientTokenURIOutputs} from "src/error/ErrFlow.sol";
 
 contract FlowConstructionInitializeTest is FlowERC721Test {
     function testFlowConstructionInitializeERC721(address expression, bytes memory bytecode, uint256[] memory constants)

--- a/test/concrete/flowErc721/FlowConstructionInitializeTest.sol
+++ b/test/concrete/flowErc721/FlowConstructionInitializeTest.sol
@@ -7,6 +7,7 @@ import {FlowERC721ConfigV2} from "src/interface/unstable/IFlowERC721V5.sol";
 import {EvaluableConfigV3} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {IExpressionDeployerV3} from "rain.interpreter.interface/interface/IExpressionDeployerV3.sol";
 import {FlowERC721Test} from "test/abstract/FlowERC721Test.sol";
+import {InsufficientTokenURIOutputs} from "src/error/ErrFlow.sol";
 
 contract FlowConstructionInitializeTest is FlowERC721Test {
     function testFlowConstructionInitializeERC721(address expression, bytes memory bytecode, uint256[] memory constants)
@@ -45,5 +46,35 @@ contract FlowConstructionInitializeTest is FlowERC721Test {
 
         assertEq(sender, address(iCloneErc721Factory), "wrong sender in Initialize event");
         assertEq(keccak256(abi.encode(flowERC721ConfigV2)), keccak256(abi.encode(config)), "wrong compare Structs");
+    }
+
+    function testFlowConstructionBadCallerMetaERC721(
+        address expression,
+        bytes memory bytecode,
+        uint256[] memory constants,
+        string memory name,
+        string memory symbol,
+        string memory baseUri
+    ) external {
+        // Define callerMeta
+        bytes memory invalidCallerMeta = bytes(hex"00000006");
+
+        EvaluableConfigV3[] memory flowConfig = new EvaluableConfigV3[](1);
+        flowConfig[0] = EvaluableConfigV3(iDeployer, bytecode, constants);
+
+        FlowERC721ConfigV2 memory flowERC721ConfigV2 = FlowERC721ConfigV2(
+            name, symbol, baseUri, EvaluableConfigV3(iDeployerForEvalHandleTransfer, bytecode, constants), flowConfig
+        );
+
+        // Test with invalid callerMeta
+        vm.mockCall(
+            address(iDeployerForEvalHandleTransfer),
+            abi.encodeWithSelector(IExpressionDeployerV3.deployExpression2.selector),
+            abi.encode(iInterpreter, iStore, expression, invalidCallerMeta)
+        );
+
+        // Expecting revert due to bad callerMeta
+        vm.expectRevert();
+        iCloneErc721Factory.clone(address(iFlowERC721Implementation), abi.encode(flowERC721ConfigV2));
     }
 }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Porting legacy tests from ".FlowERC721/construction" — test case "should fail if flowERC721 is deployed with bad callerMeta"
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add test in foundry
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
