### PR TITLE
FlowERC1155 construction initialize tests

### DIFF
--- a/test/concrete/flowErc1155/FlowConstructionInitializeTest.sol
+++ b/test/concrete/flowErc1155/FlowConstructionInitializeTest.sol
@@ -37,4 +37,20 @@ contract FlowConstructionInitializeTest is FlowERC1155Test {
         assertEq(sender, address(iCloneErc1155Factory), "wrong sender in Initialize event");
         assertEq(keccak256(abi.encode(flowERC1155ConfigV3)), keccak256(abi.encode(config)), "wrong compare Structs");
     }
+
+    function testFlowConstructionBadCallerMetaERC1155(
+        bytes memory bytecode,
+        uint256[] memory constants,
+        string memory uri
+    ) external {
+        EvaluableConfigV3[] memory flowConfig = new EvaluableConfigV3[](1);
+        flowConfig[0] = EvaluableConfigV3(iDeployer, bytecode, constants);
+
+        FlowERC1155ConfigV3 memory flowERC1155ConfigV3 =
+            FlowERC1155ConfigV3(uri, EvaluableConfigV3(iDeployer, bytecode, constants), flowConfig);
+
+        // Expecting revert due to bad callerMeta
+        vm.expectRevert();
+        iCloneErc1155Factory.clone(address(iFlowErc1155Implementation), abi.encode(flowERC1155ConfigV3));
+    }
 }

--- a/test/concrete/flowErc1155/FlowConstructionInitializeTest.sol
+++ b/test/concrete/flowErc1155/FlowConstructionInitializeTest.sol
@@ -12,7 +12,8 @@ contract FlowConstructionInitializeTest is FlowERC1155Test {
     function testFlowConstructionInitializeERC1155(
         address expression,
         bytes memory bytecode,
-        uint256[] memory constants
+        uint256[] memory constants,
+        string memory uri
     ) external {
         expressionDeployerDeployExpression2MockCall(expression, bytes(hex"0007"));
 
@@ -20,7 +21,7 @@ contract FlowConstructionInitializeTest is FlowERC1155Test {
         flowConfig[0] = EvaluableConfigV3(iDeployer, bytecode, constants);
 
         FlowERC1155ConfigV3 memory flowERC1155ConfigV3 =
-            FlowERC1155ConfigV3("uri", EvaluableConfigV3(iDeployer, bytecode, constants), flowConfig);
+            FlowERC1155ConfigV3(uri, EvaluableConfigV3(iDeployer, bytecode, constants), flowConfig);
 
         vm.recordLogs();
         iCloneErc1155Factory.clone(address(iFlowErc1155Implementation), abi.encode(flowERC1155ConfigV3));

--- a/test/concrete/flowErc1155/FlowConstructionInitializeTest.sol
+++ b/test/concrete/flowErc1155/FlowConstructionInitializeTest.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: CAL
+pragma solidity =0.8.19;
+
+import {Vm} from "forge-std/Test.sol";
+
+import {FlowERC1155ConfigV3} from "src/interface/unstable/IFlowERC1155V5.sol";
+import {EvaluableConfigV3} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
+import {IExpressionDeployerV3} from "rain.interpreter.interface/interface/IExpressionDeployerV3.sol";
+import {FlowERC1155Test} from "test/abstract/FlowERC1155Test.sol";
+
+contract FlowConstructionInitializeTest is FlowERC1155Test {
+    function testFlowConstructionInitializeERC1155(
+        address expression,
+        bytes memory bytecode,
+        uint256[] memory constants
+    ) external {
+        expressionDeployerDeployExpression2MockCall(expression, bytes(hex"0007"));
+
+        EvaluableConfigV3[] memory flowConfig = new EvaluableConfigV3[](1);
+        flowConfig[0] = EvaluableConfigV3(iDeployer, bytecode, constants);
+
+        FlowERC1155ConfigV3 memory flowERC1155ConfigV3 =
+            FlowERC1155ConfigV3("uri", EvaluableConfigV3(iDeployer, bytecode, constants), flowConfig);
+
+        vm.recordLogs();
+        iCloneErc1155Factory.clone(address(iFlowErc1155Implementation), abi.encode(flowERC1155ConfigV3));
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 eventSignature =
+            keccak256("Initialize(address,(string,(address,bytes,uint256[]),(address,bytes,uint256[])[]))");
+
+        Vm.Log memory concreteEvent = findEvent(logs, eventSignature);
+        (address sender, FlowERC1155ConfigV3 memory config) =
+            abi.decode(concreteEvent.data, (address, FlowERC1155ConfigV3));
+
+        assertEq(sender, address(iCloneErc1155Factory), "wrong sender in Initialize event");
+        assertEq(keccak256(abi.encode(flowERC1155ConfigV3)), keccak256(abi.encode(config)), "wrong compare Structs");
+    }
+}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Porting legacy tests from ".FlowERC1155/construction" — test case "should initialize on the good path"
Porting legacy tests from ".FlowERC1155/construction" — test case "should fail if flowERC1155 is deployed with bad callerMeta"

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add foundry tests
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
