### PR TITLE
Test FlowErc721 Halt If Ensure Requirement Not Met

### DIFF
--- a/test/concrete/flowErc721/Erc721FlowTest.sol
+++ b/test/concrete/flowErc721/Erc721FlowTest.sol
@@ -28,6 +28,9 @@ import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpr
 import {DEFAULT_STATE_NAMESPACE} from "rain.interpreter.interface/interface/IInterpreterV2.sol";
 import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
 import {MissingSentinel} from "rain.solmem/lib/LibStackSentinel.sol";
+import {FLOW_ENTRYPOINT, FLOW_MAX_OUTPUTS} from "src/abstract/FlowCommon.sol";
+import {LibEncodedDispatch} from "rain.interpreter.interface/lib/caller/LibEncodedDispatch.sol";
+import {LibContextWrapper} from "test/lib/LibContextWrapper.sol";
 
 contract Erc721FlowTest is FlowERC721Test {
     using LibEvaluable for EvaluableV2;
@@ -498,5 +501,30 @@ contract Erc721FlowTest is FlowERC721Test {
         vm.expectRevert(abi.encodeWithSelector(MissingSentinel.selector, sentinel));
         flowInvalid.flow(evaluablesInvalid[0], new uint256[](0), new SignedContextV1[](0));
         vm.stopPrank();
+    }
+
+    /**
+     * @notice Tests that the flow halts if it does not meet the 'ensure' requirement.
+     */
+    /// forge-config: default.fuzz.runs = 100
+    function testFlowErc721HaltIfEnsureRequirementNotMet() external {
+        (IFlowERC721V5 flow, EvaluableV2 memory evaluable) =
+            deployFlowERC721("FlowERC721", "F721", "https://www.rainprotocol.xyz/nft/");
+
+        assumeEtchable(address(0), address(flow));
+
+        (uint256[] memory stack,) = mintAndBurnFlowStack(address(this), 20 ether, 10 ether, 5, transferEmpty());
+        interpreterEval2MockCall(stack, new uint256[](0));
+
+        uint256[][] memory context = LibContextWrapper.buildAndSetContext(
+            new uint256[](0), new SignedContextV1[](0), address(this), address(flow)
+        );
+
+        interpreterEval2RevertCall(
+            address(flow), LibEncodedDispatch.encode2(evaluable.expression, FLOW_ENTRYPOINT, FLOW_MAX_OUTPUTS), context
+        );
+
+        vm.expectRevert("REVERT_EVAL2_CALL");
+        flow.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
     }
 }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
Porting legacy tests from ".FlowERC721/previewFlow" — test case "should not flow if it does not meet 'ensure' requirement"
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add test in foundry
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
