### PR TITLE
delete empty ErrFLow contract

### DIFF
--- a/src/error/ErrFlow.sol
+++ b/src/error/ErrFlow.sol
@@ -18,8 +18,6 @@ error UnsupportedERC721Flow();
 /// Thrown for unsupported erc1155 transfers.
 error UnsupportedERC1155Flow();
 
-contract ErrFLow {}
-
 /// Thrown when burner of tokens is not the owner of tokens.
 error BurnerNotOwner();
 


### PR DESCRIPTION
## Summary
- Delete empty typo'd `contract ErrFLow {}` from `src/error/ErrFlow.sol`. Verified unreferenced anywhere in `src/`, `test/`, or `lib/`.

## Test plan
- [x] `nix develop -c forge build` — clean.
- [x] full test suite via `rainix-sol-test` — 27/27.
- [x] `rainix-sol-static` — exit 0.

Closes #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused contract declaration while preserving all error definitions for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->