### PR TITLE
fix IFlowV5 return data location calldata to memory

### DIFF
--- a/src/interface/IFlowV5.sol
+++ b/src/interface/IFlowV5.sol
@@ -149,7 +149,7 @@ interface IFlowV5 {
     /// gating that would exclude the caller, etc.
     /// @param stack The stack of values to convert to a flow transfer.
     /// @return flowTransfer The resulting flow transfer.
-    function stackToFlow(uint256[] memory stack) external pure returns (FlowTransferV1 calldata flowTransfer);
+    function stackToFlow(uint256[] memory stack) external pure returns (FlowTransferV1 memory flowTransfer);
 
     /// Given an evaluable, caller context, and signed contexts, evaluate the
     /// evaluable and return the resulting flow transfer. MUST process the
@@ -168,5 +168,5 @@ interface IFlowV5 {
         EvaluableV2 calldata evaluable,
         uint256[] calldata callerContext,
         SignedContextV1[] calldata signedContexts
-    ) external returns (FlowTransferV1 calldata flowTransfer);
+    ) external returns (FlowTransferV1 memory flowTransfer);
 }


### PR DESCRIPTION
## Summary
- `IFlowV5.sol`: change return data location from `calldata` to `memory` on `stackToFlow` (L152) and `flow` (L171). `calldata` on return values is a no-op at the ABI level — returns land in returndata, not calldata — and the implementation in `Flow.sol` already returns `memory`. The interface declaration was misleading.

## Test plan
- [x] `nix develop -c forge build` — clean.
- [x] full test suite via `rainix-sol-test` — 27/27.
- [x] `rainix-sol-static` — exit 0.

No test added: the change has no observable behavior to reproduce.

Closes #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
