### PR TITLE
move dead errors from ErrFlow.sol to earliest interface

### DIFF
--- a/src/error/ErrFlow.sol
+++ b/src/error/ErrFlow.sol
@@ -6,9 +6,6 @@ pragma solidity ^0.8.25;
 /// @param unregisteredHash Hash of the unregistered flow.
 error UnregisteredFlow(bytes32 unregisteredHash);
 
-/// Thrown for unsupported native transfers.
-error UnsupportedNativeFlow();
-
 /// Thrown for unsupported erc20 transfers.
 error UnsupportedERC20Flow();
 
@@ -18,12 +15,10 @@ error UnsupportedERC721Flow();
 /// Thrown for unsupported erc1155 transfers.
 error UnsupportedERC1155Flow();
 
-/// Thrown when burner of tokens is not the owner of tokens.
-error BurnerNotOwner();
-
-error UnsupportedHandleTransferInputs();
-error InsufficientHandleTransferOutputs();
-error UnsupportedTokenURIInputs();
-error InsufficientTokenURIOutputs();
+/// Thrown when a flow's `evaluable` declares any inputs.
+/// `flow` evaluables are dispatched without inputs.
 error UnsupportedFlowInputs();
+
+/// Thrown when a flow's `evaluable` declares fewer outputs than the flow's
+/// minimum (`MIN_FLOW_SENTINELS`).
 error InsufficientFlowOutputs();

--- a/src/interface/deprecated/v1/IFlowERC721V1.sol
+++ b/src/interface/deprecated/v1/IFlowERC721V1.sol
@@ -9,6 +9,9 @@ import {
 } from "rain.interpreter.interface/interface/deprecated/IInterpreterCallerV1.sol";
 import {FlowTransfer} from "./IFlowV1.sol";
 
+/// Thrown when burner of tokens is not the owner of tokens.
+error BurnerNotOwner();
+
 /// Constructor config.
 /// @param Constructor config for the ERC721 token minted according to flow
 /// schedule in `flow`.

--- a/src/interface/deprecated/v1/IFlowV1.sol
+++ b/src/interface/deprecated/v1/IFlowV1.sol
@@ -8,6 +8,9 @@ import {
     SignedContext
 } from "rain.interpreter.interface/interface/deprecated/IInterpreterCallerV1.sol";
 
+/// Thrown for unsupported native transfers.
+error UnsupportedNativeFlow();
+
 struct FlowConfig {
     // https://github.com/ethereum/solidity/issues/13597
     EvaluableConfig dummyConfig;

--- a/src/interface/deprecated/v2/IFlowV2.sol
+++ b/src/interface/deprecated/v2/IFlowV2.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.25;
 
 import {Evaluable, EvaluableConfig} from "rain.interpreter.interface/interface/deprecated/IInterpreterCallerV1.sol";
 import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
+//forge-lint: disable-next-line(unused-import)
+import {UnsupportedNativeFlow} from "../v1/IFlowV1.sol";
 
 struct FlowConfig {
     // https://github.com/ethereum/solidity/issues/13597

--- a/src/interface/deprecated/v3/IFlowERC1155V3.sol
+++ b/src/interface/deprecated/v3/IFlowERC1155V3.sol
@@ -14,6 +14,14 @@ import {
     Evaluable
 } from "./IFlowV3.sol";
 
+/// Thrown when the `handleTransfer` evaluable declares any inputs.
+/// `handleTransfer` is dispatched as a callback with no inputs.
+error UnsupportedHandleTransferInputs();
+
+/// Thrown when the `handleTransfer` evaluable declares fewer outputs than
+/// `FLOW_ERC1155_HANDLE_TRANSFER_MIN_OUTPUTS`.
+error InsufficientHandleTransferOutputs();
+
 /// @dev Entrypont of the `handleTransfer` evaluation.
 SourceIndex constant FLOW_ERC1155_HANDLE_TRANSFER_ENTRYPOINT = SourceIndex.wrap(0);
 

--- a/src/interface/deprecated/v3/IFlowERC20V3.sol
+++ b/src/interface/deprecated/v3/IFlowERC20V3.sol
@@ -7,6 +7,7 @@ import {EvaluableConfig, Evaluable} from "rain.interpreter.interface/interface/d
 import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
 import {MIN_FLOW_SENTINELS, SENTINEL_HIGH_BITS, FlowTransferV1} from "./IFlowV3.sol";
+import {UnsupportedHandleTransferInputs, InsufficientHandleTransferOutputs} from "./IFlowERC1155V3.sol";
 
 /// @dev v3 of `FlowERC20` expected a sentinel different to
 /// `RAIN_FLOW_SENTINEL`, but this was generally more confusing than helpful.

--- a/src/interface/deprecated/v3/IFlowERC721V3.sol
+++ b/src/interface/deprecated/v3/IFlowERC721V3.sol
@@ -13,6 +13,15 @@ import {
     FlowTransferV1,
     Evaluable
 } from "./IFlowV3.sol";
+import {UnsupportedHandleTransferInputs, InsufficientHandleTransferOutputs} from "./IFlowERC1155V3.sol";
+
+/// Thrown when the `tokenURI` evaluable declares any inputs.
+/// `tokenURI` is dispatched with no inputs.
+error UnsupportedTokenURIInputs();
+
+/// Thrown when the `tokenURI` evaluable declares fewer outputs than
+/// `FLOW_ERC721_TOKEN_URI_MIN_OUTPUTS`.
+error InsufficientTokenURIOutputs();
 
 /// @dev Entrypont of the `handleTransfer` evaluation.
 SourceIndex constant FLOW_ERC721_HANDLE_TRANSFER_ENTRYPOINT = SourceIndex.wrap(0);

--- a/src/interface/deprecated/v4/IFlowERC1155V4.sol
+++ b/src/interface/deprecated/v4/IFlowERC1155V4.sol
@@ -29,6 +29,8 @@ import {
     //forge-lint: disable-next-line(unused-import)
     FLOW_ERC1155_MIN_FLOW_SENTINELS
 } from "../v3/IFlowERC1155V3.sol";
+//forge-lint: disable-next-line(unused-import)
+import {UnsupportedHandleTransferInputs, InsufficientHandleTransferOutputs} from "../v3/IFlowERC1155V3.sol";
 
 /// Initialization config.
 /// @param uri As per Open Zeppelin `ERC1155Upgradeable`.

--- a/src/interface/deprecated/v4/IFlowERC20V4.sol
+++ b/src/interface/deprecated/v4/IFlowERC20V4.sol
@@ -26,6 +26,8 @@ import {
 } from "../v3/IFlowERC20V3.sol";
 //forge-lint: disable-next-line(unused-import)
 import {RAIN_FLOW_SENTINEL} from "./IFlowV4.sol";
+//forge-lint: disable-next-line(unused-import)
+import {UnsupportedHandleTransferInputs, InsufficientHandleTransferOutputs} from "../v3/IFlowERC1155V3.sol";
 
 /// Initialization config.
 /// @param name As per Open Zeppelin `ERC20Upgradeable`.

--- a/src/interface/deprecated/v4/IFlowERC721V4.sol
+++ b/src/interface/deprecated/v4/IFlowERC721V4.sol
@@ -35,9 +35,12 @@ import {
 
 //forge-lint: disable-next-line(unused-import)
 import {RAIN_FLOW_SENTINEL} from "./IFlowV4.sol";
-
-/// Thrown when burner of tokens is not the owner of tokens.
-error BurnerNotOwner();
+//forge-lint: disable-next-line(unused-import)
+import {BurnerNotOwner} from "../v1/IFlowERC721V1.sol";
+//forge-lint: disable-next-line(unused-import)
+import {UnsupportedHandleTransferInputs, InsufficientHandleTransferOutputs} from "../v3/IFlowERC1155V3.sol";
+//forge-lint: disable-next-line(unused-import)
+import {UnsupportedTokenURIInputs, InsufficientTokenURIOutputs} from "../v3/IFlowERC721V3.sol";
 
 /// Initialization config.
 /// @param name As per Open Zeppelin `ERC721Upgradeable`.

--- a/src/interface/deprecated/v5/IFlowERC1155V5.sol
+++ b/src/interface/deprecated/v5/IFlowERC1155V5.sol
@@ -25,6 +25,8 @@ import {
     //forge-lint: disable-next-line(unused-import)
     FLOW_ERC1155_MIN_FLOW_SENTINELS
 } from "../v4/IFlowERC1155V4.sol";
+//forge-lint: disable-next-line(unused-import)
+import {UnsupportedHandleTransferInputs, InsufficientHandleTransferOutputs} from "../v3/IFlowERC1155V3.sol";
 
 SourceIndexV2 constant FLOW_ERC1155_HANDLE_TRANSFER_ENTRYPOINT = SourceIndexV2.wrap(0);
 

--- a/src/interface/deprecated/v5/IFlowERC20V5.sol
+++ b/src/interface/deprecated/v5/IFlowERC20V5.sol
@@ -24,6 +24,8 @@ import {
 } from "../v4/IFlowERC20V4.sol";
 //forge-lint: disable-next-line(unused-import)
 import {RAIN_FLOW_SENTINEL} from "../../IFlowV5.sol";
+//forge-lint: disable-next-line(unused-import)
+import {UnsupportedHandleTransferInputs, InsufficientHandleTransferOutputs} from "../v3/IFlowERC1155V3.sol";
 
 SourceIndexV2 constant FLOW_ERC20_HANDLE_TRANSFER_ENTRYPOINT = SourceIndexV2.wrap(0);
 

--- a/src/interface/deprecated/v5/IFlowERC721V5.sol
+++ b/src/interface/deprecated/v5/IFlowERC721V5.sol
@@ -28,6 +28,10 @@ import {
 } from "../v4/IFlowERC721V4.sol";
 //forge-lint: disable-next-line(unused-import)
 import {RAIN_FLOW_SENTINEL} from "../v4/IFlowV4.sol";
+//forge-lint: disable-next-line(unused-import)
+import {UnsupportedHandleTransferInputs, InsufficientHandleTransferOutputs} from "../v3/IFlowERC1155V3.sol";
+//forge-lint: disable-next-line(unused-import)
+import {UnsupportedTokenURIInputs, InsufficientTokenURIOutputs} from "../v3/IFlowERC721V3.sol";
 
 SourceIndexV2 constant FLOW_ERC721_HANDLE_TRANSFER_ENTRYPOINT = SourceIndexV2.wrap(0);
 SourceIndexV2 constant FLOW_ERC721_TOKEN_URI_ENTRYPOINT = SourceIndexV2.wrap(1);


### PR DESCRIPTION
## Summary

Six errors in `src/error/ErrFlow.sol` described functionality that only existed in deprecated paths and were never reverted by live code. Each is moved to the earliest deprecated interface where its concept was introduced; subsequent versions that retained the concept import the symbol back from the earliest declaration.

| Error | Earliest declaration | Re-exported from |
|---|---|---|
| `UnsupportedNativeFlow` | `IFlowV1.sol` | `IFlowV2.sol` |
| `BurnerNotOwner` | `IFlowERC721V1.sol` | `IFlowERC721V4.sol` (replacing local redeclaration) |
| `UnsupportedHandleTransferInputs` / `InsufficientHandleTransferOutputs` | `IFlowERC1155V3.sol` | V3 ERC20, V3 ERC721, V4 ERC{20,721,1155}, V5 ERC{20,721,1155} |
| `UnsupportedTokenURIInputs` / `InsufficientTokenURIOutputs` | `IFlowERC721V3.sol` | V4 ERC721, V5 ERC721 |

`ErrFlow.sol` now contains only live-reverted errors plus updated NatSpec on `UnsupportedFlowInputs` and `InsufficientFlowOutputs`.

## Test plan
- [x] `nix develop -c forge build` — clean.
- [x] full test suite via `rainix-sol-test` — 27/27.
- [x] `rainix-sol-static` — exit 0 (after `forge fmt` sweep on touched files).

Closes #274, #276, #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated error definitions for flow validation, replacing multiple granular error types with streamlined standardized errors
  * Updated deprecated interface versions to reference centralized error definitions for consistency across the codebase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->