### PR TITLE
dedupe MIN_FLOW_SENTINELS import in Flow.sol

### DIFF
--- a/src/concrete/Flow.sol
+++ b/src/concrete/Flow.sol
@@ -11,7 +11,7 @@ import {
 } from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {LibEncodedDispatch} from "rain.interpreter.interface/lib/caller/LibEncodedDispatch.sol";
 import {LibContext} from "rain.interpreter.interface/lib/caller/LibContext.sol";
-import {UnregisteredFlow, MIN_FLOW_SENTINELS} from "../interface/IFlowV5.sol";
+import {UnregisteredFlow} from "../interface/IFlowV5.sol";
 import {LibEvaluable, EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {
     SourceIndexV2,


### PR DESCRIPTION
## Summary
- `Flow.sol` imports `MIN_FLOW_SENTINELS` twice from the same source (lines 14 and 37). Drop the duplicate from line 14; line 37 keeps the canonical import alongside `IFlowV5` and `FlowTransferV1`.

## Test plan
- [x] `nix develop -c forge build` — clean.
- [x] full test suite — 27/27.
- [x] `rainix-sol-static` — exit 0.

Closes #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
