### PR TITLE
harmonise from-allowed check across LibFlow.flowERC20/721/1155

### DIFF
--- a/src/lib/LibFlow.sol
+++ b/src/lib/LibFlow.sol
@@ -78,14 +78,18 @@ library LibFlow {
             ERC20Transfer memory transfer;
             for (uint256 i = 0; i < flowTransfer.erc20.length; i++) {
                 transfer = flowTransfer.erc20[i];
+                // We don't support `from` as anyone other than `you` or `me`
+                // as this would allow for all kinds of issues re: approvals.
+                if (transfer.from != msg.sender && transfer.from != address(this)) {
+                    revert UnsupportedERC20Flow();
+                }
+                // OZ ERC20 `transferFrom` consumes allowance even when
+                // `from == msg.sender`, so the self-flow branch must use
+                // `safeTransfer` instead.
                 if (transfer.from == msg.sender) {
                     IERC20(transfer.token).safeTransferFrom(msg.sender, transfer.to, transfer.amount);
-                } else if (transfer.from == address(this)) {
-                    IERC20(transfer.token).safeTransfer(transfer.to, transfer.amount);
                 } else {
-                    // We don't support `from` as anyone other than `you` or `me`
-                    // as this would allow for all kinds of issues re: approvals.
-                    revert UnsupportedERC20Flow();
+                    IERC20(transfer.token).safeTransfer(transfer.to, transfer.amount);
                 }
             }
         }


### PR DESCRIPTION
## Summary

`flowERC20` used an `if/else if/else` branch for the from-allowed check while `flowERC721` and `flowERC1155` used a `!=`-predicate gate. The divergence forced a reader to reverify the same security-critical invariant in two different shapes.

`flowERC20` now matches the `!=`-predicate style. The OZ-allowance branch that selects `safeTransfer` vs `safeTransferFrom` is kept separately, with a comment explaining why self-flow must use `safeTransfer` (OZ ERC20 `transferFrom` consumes allowance from the caller, even when caller == self).

## Test plan
- [x] `forge build` — clean.
- [x] full suite — 30/30.
- [x] `rainix-sol-static` — exit 0.

Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ERC20 transfer validation to ensure only authorized addresses can initiate transfers.

* **Documentation**
  * Added inline documentation clarifying transfer behavior and allowance handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->