### PR TITLE
delete stale @todo comments in LibFlow.flowERC1155

### DIFF
--- a/src/lib/LibFlow.sol
+++ b/src/lib/LibFlow.sol
@@ -128,8 +128,6 @@ library LibFlow {
                 if (transfer.from != msg.sender && transfer.from != address(this)) {
                     revert UnsupportedERC1155Flow();
                 }
-                // @todo safeBatchTransferFrom support.
-                // @todo data support.
                 IERC1155(transfer.token).safeTransferFrom(transfer.from, transfer.to, transfer.id, transfer.amount, "");
             }
         }


### PR DESCRIPTION
## Summary

`LibFlow.flowERC1155` carried two `@todo` markers (`safeBatchTransferFrom support`, `data support`). Neither is a correctness defect under FlowV5 — per-transfer dispatch with empty `data` is spec-compliant. Each marker is now split into its own tracked enhancement so they can be evaluated separately:

- #434 — Evaluate ERC1155 batch transfer support
- #435 — Evaluate ERC1155 transfer data parameter support

The source no longer carries the TODOs; FlowV5 behaviour is final until either follow-up issue is decided.

## Test plan
- [x] `forge build` — clean.
- [x] full suite — 30/30.
- [x] `rainix-sol-static` — exit 0.

Closes #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
