### PR TITLE
document empty-kvs short-circuit in LibFlow.flow NatSpec

### DIFF
--- a/src/lib/LibFlow.sol
+++ b/src/lib/LibFlow.sol
@@ -137,6 +137,9 @@ library LibFlow {
     /// interpreter store. Then processes the ERC20, ERC721 and ERC1155 transfers
     /// in the flow. Guarantees ordering of the transfers but DOES NOT prevent
     /// reentrancy attacks. This is the responsibility of the caller.
+    /// `set` is skipped entirely when `kvs.length == 0`. Stores that need to
+    /// observe every flow invocation (e.g. for audit logging) cannot rely on
+    /// `set` being called for empty kvs.
     /// @param flowTransfer The `FlowTransferV1` to process.
     /// @param interpreterStore The `IInterpreterStoreV1` to set state on.
     /// @param kvs The key value pairs to set on the interpreter store.


### PR DESCRIPTION
## Summary

`LibFlow.flow` skips the `interpreterStore.set` call entirely when `kvs.length == 0` as a gas optimisation. The behaviour is intentional and is now stated in the NatSpec so custom stores cannot incorrectly assume `set` is invoked on every flow.

## Test plan
- [x] `forge build` — clean.
- [x] full suite — 30/30.
- [x] `rainix-sol-static` — exit 0.

Closes #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to explicitly clarify how the system handles scenarios with empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->