### PR TITLE
test UnsupportedFlowInputs revert in flowInit

### DIFF
--- a/test/src/concrete/Flow.construction.t.sol
+++ b/test/src/concrete/Flow.construction.t.sol
@@ -6,7 +6,7 @@ import {Vm} from "forge-std/Test.sol";
 
 import {EvaluableConfigV3} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {FlowTest} from "test/abstract/FlowTest.sol";
-import {EmptyFlowConfig} from "src/error/ErrFlow.sol";
+import {EmptyFlowConfig, UnsupportedFlowInputs} from "src/error/ErrFlow.sol";
 
 contract FlowConstructionTest is FlowTest {
     function testFlowConstructionEmptyConfigReverts() external {
@@ -14,6 +14,30 @@ contract FlowConstructionTest is FlowTest {
         address impl = deployFlowImplementation();
         vm.expectRevert(EmptyFlowConfig.selector);
         I_CLONE_FACTORY.clone(impl, abi.encode(emptyConfig));
+    }
+
+    /// Reverts with `UnsupportedFlowInputs` when the deployer reports any
+    /// non-zero `flowInputs` byte in the IO string. Pinning this protects
+    /// against a future deployer behaviour change leaking non-zero inputs
+    /// through the guard at `Flow.flowInit`.
+    /// forge-config: default.fuzz.runs = 100
+    function testFlowConstructionRevertsOnNonZeroFlowInputs(
+        address expression,
+        bytes memory bytecode,
+        uint256[] memory constants,
+        uint8 flowInputs
+    ) external {
+        vm.assume(flowInputs != 0);
+        // io: byte0 = flowInputs (non-zero), byte1 = 7 (>= MIN_FLOW_SENTINELS).
+        bytes memory io = abi.encodePacked(flowInputs, uint8(7));
+        expressionDeployerDeployExpression2MockCall(expression, io);
+
+        EvaluableConfigV3[] memory flowConfig = new EvaluableConfigV3[](1);
+        flowConfig[0] = EvaluableConfigV3(DEPLOYER, bytecode, constants);
+
+        address impl = deployFlowImplementation();
+        vm.expectRevert(UnsupportedFlowInputs.selector);
+        I_CLONE_FACTORY.clone(impl, abi.encode(flowConfig));
     }
 
     function testFlowConstructionInitialize(address expression, bytes memory bytecode, uint256[] memory constants)


### PR DESCRIPTION
## Summary

Pins the `flowInit` guard that rejects any non-zero `flowInputs` byte returned by the deployer.

`Flow.sol:210` reverts with `UnsupportedFlowInputs` when `flowInputs != 0`. No prior test exercised this branch; the only mock IO strings used in tests had `flowInputs == 0`, so a regression here would not have been caught.

The new fuzz test mocks the deployer to return a non-zero `flowInputs` byte and asserts the revert selector. **Mutation verified**: inverting the check (`!= 0` → `== 0`) makes the test fail; reverting passes.

Closes #310 #320.

## Test plan

- [x] `testFlowConstructionRevertsOnNonZeroFlowInputs` — 100 fuzz runs, all pass
- [x] mutation: invert the check in `Flow.sol:210` → test fails
- [x] static via `rainix-sol-static`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
