### PR TITLE
test InsufficientFlowOutputs revert and boundary

### DIFF
--- a/test/src/concrete/Flow.construction.t.sol
+++ b/test/src/concrete/Flow.construction.t.sol
@@ -6,7 +6,8 @@ import {Vm} from "forge-std/Test.sol";
 
 import {EvaluableConfigV3} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {FlowTest} from "test/abstract/FlowTest.sol";
-import {EmptyFlowConfig} from "src/error/ErrFlow.sol";
+import {EmptyFlowConfig, InsufficientFlowOutputs} from "src/error/ErrFlow.sol";
+import {MIN_FLOW_SENTINELS} from "src/interface/IFlowV5.sol";
 
 contract FlowConstructionTest is FlowTest {
     function testFlowConstructionEmptyConfigReverts() external {
@@ -14,6 +15,45 @@ contract FlowConstructionTest is FlowTest {
         address impl = deployFlowImplementation();
         vm.expectRevert(EmptyFlowConfig.selector);
         I_CLONE_FACTORY.clone(impl, abi.encode(emptyConfig));
+    }
+
+    /// Reverts with `InsufficientFlowOutputs` when the deployer reports a
+    /// `flowOutputs` byte below `MIN_FLOW_SENTINELS` (= 3). Pinning this
+    /// protects the lower-bound guard at `Flow.flowInit` against regression.
+    /// forge-config: default.fuzz.runs = 100
+    function testFlowConstructionRevertsOnInsufficientFlowOutputs(
+        address expression,
+        bytes memory bytecode,
+        uint256[] memory constants,
+        uint8 flowOutputs
+    ) external {
+        vm.assume(flowOutputs < uint8(MIN_FLOW_SENTINELS));
+        bytes memory io = abi.encodePacked(uint8(0), flowOutputs);
+        expressionDeployerDeployExpression2MockCall(expression, io);
+
+        EvaluableConfigV3[] memory flowConfig = new EvaluableConfigV3[](1);
+        flowConfig[0] = EvaluableConfigV3(DEPLOYER, bytecode, constants);
+
+        address impl = deployFlowImplementation();
+        vm.expectRevert(InsufficientFlowOutputs.selector);
+        I_CLONE_FACTORY.clone(impl, abi.encode(flowConfig));
+    }
+
+    /// `flowOutputs == MIN_FLOW_SENTINELS` is the lowest accepted value.
+    /// Pinning this boundary against regression complements the negative
+    /// test above.
+    function testFlowConstructionAcceptsFlowOutputsAtMin(
+        address expression,
+        bytes memory bytecode,
+        uint256[] memory constants
+    ) external {
+        bytes memory io = abi.encodePacked(uint8(0), uint8(MIN_FLOW_SENTINELS));
+        expressionDeployerDeployExpression2MockCall(expression, io);
+
+        EvaluableConfigV3[] memory flowConfig = new EvaluableConfigV3[](1);
+        flowConfig[0] = EvaluableConfigV3(DEPLOYER, bytecode, constants);
+
+        I_CLONE_FACTORY.clone(deployFlowImplementation(), abi.encode(flowConfig));
     }
 
     function testFlowConstructionInitialize(address expression, bytes memory bytecode, uint256[] memory constants)


### PR DESCRIPTION
## Summary

Pins the `flowInit` guard that rejects deployer-returned `flowOutputs < MIN_FLOW_SENTINELS` (= 3). Two tests:

- **Negative** (fuzzed): any `flowOutputs` in `[0, MIN_FLOW_SENTINELS)` reverts with `InsufficientFlowOutputs`.
- **Boundary**: `flowOutputs == MIN_FLOW_SENTINELS` is accepted (lowest valid value).

**Mutation verified**: inverting the check (`<` → `>=`) makes both tests fail; reverting passes.

Closes #311 #321.

## Test plan

- [x] `testFlowConstructionRevertsOnInsufficientFlowOutputs` — 100 fuzz runs
- [x] `testFlowConstructionAcceptsFlowOutputsAtMin` — 2048 fuzz runs
- [x] mutation: invert the check in `Flow.sol:206` → both tests fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added validation tests to verify flow initialization rejects insufficient output parameters
  * Added boundary condition tests confirming minimum acceptable output values are properly handled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->