### PR TITLE
test malformed-stack reverts in flow() and stackToFlow()

### DIFF
--- a/test/src/concrete/Flow.preview.t.sol
+++ b/test/src/concrete/Flow.preview.t.sol
@@ -3,6 +3,7 @@
 pragma solidity =0.8.25;
 
 import {FlowTest} from "test/abstract/FlowTest.sol";
+import {MissingSentinel, Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
 import {
     IFlowV5,
     FlowTransferV1,
@@ -235,5 +236,33 @@ contract FlowPreviewTest is FlowTest {
         assertEq(result.erc1155[0].to, address(uint160(0xC2)), "erc1155 to");
         assertEq(result.erc1155[0].id, 0xC3C3, "erc1155 id");
         assertEq(result.erc1155[0].amount, 0xC4C4, "erc1155 amount");
+    }
+
+    /// `IFlowV5.stackToFlow` MAY revert if the stack is malformed. The
+    /// observable revert is `MissingSentinel(RAIN_FLOW_SENTINEL)` from
+    /// `LibStackSentinel.consumeSentinelTuples` when any of the three
+    /// required sentinels is absent.
+    function testStackToFlowRevertsOnEmptyStack() external {
+        (IFlowV5 flow,) = deployFlow();
+        uint256[] memory stack = new uint256[](0);
+        vm.expectRevert(abi.encodeWithSelector(MissingSentinel.selector, RAIN_FLOW_SENTINEL));
+        flow.stackToFlow(stack);
+    }
+
+    function testStackToFlowRevertsOnOneSentinelOnly() external {
+        (IFlowV5 flow,) = deployFlow();
+        uint256[] memory stack = new uint256[](1);
+        stack[0] = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
+        vm.expectRevert(abi.encodeWithSelector(MissingSentinel.selector, RAIN_FLOW_SENTINEL));
+        flow.stackToFlow(stack);
+    }
+
+    function testStackToFlowRevertsOnTwoSentinelsOnly() external {
+        (IFlowV5 flow,) = deployFlow();
+        uint256[] memory stack = new uint256[](2);
+        stack[0] = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
+        stack[1] = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
+        vm.expectRevert(abi.encodeWithSelector(MissingSentinel.selector, RAIN_FLOW_SENTINEL));
+        flow.stackToFlow(stack);
     }
 }

--- a/test/src/concrete/Flow.transfer.t.sol
+++ b/test/src/concrete/Flow.transfer.t.sol
@@ -29,6 +29,7 @@ import {LibContextWrapper} from "test/lib/LibContextWrapper.sol";
 import {IERC721} from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
 import {IERC1155} from "openzeppelin-contracts/contracts/token/ERC1155/IERC1155.sol";
 import {LibStackGeneration} from "test/lib/LibStackGeneration.sol";
+import {MissingSentinel} from "rain.solmem/lib/LibStackSentinel.sol";
 
 /// `IERC721.safeTransferFrom` is overloaded (3-arg + 4-arg). Pin the 3-arg
 /// selector via a single-overload wrapper interface so the disambiguation
@@ -425,6 +426,44 @@ contract FlowTransferTest is FlowTest {
 
         vm.startPrank(alice);
         vm.expectRevert();
+        flow.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
+        vm.stopPrank();
+    }
+
+    /// `IFlowV5.flow()` MUST revert if the evaluable returns a malformed
+    /// stack. The observable revert is `MissingSentinel(RAIN_FLOW_SENTINEL)`
+    /// from `LibStackSentinel.consumeSentinelTuples`.
+    /// forge-config: default.fuzz.runs = 100
+    function testFlowRevertsOnEmptyEvaluatedStack(address alice) external {
+        vm.assume(alice != address(0));
+        vm.label(alice, "Alice");
+
+        (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
+        assumeEtchable(alice, address(flow));
+
+        uint256[] memory stack = new uint256[](0);
+        interpreterEval2MockCall(stack, new uint256[](0));
+
+        vm.startPrank(alice);
+        vm.expectRevert(abi.encodeWithSelector(MissingSentinel.selector, RAIN_FLOW_SENTINEL));
+        flow.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
+        vm.stopPrank();
+    }
+
+    /// forge-config: default.fuzz.runs = 100
+    function testFlowRevertsOnOneSentinelOnlyEvaluatedStack(address alice) external {
+        vm.assume(alice != address(0));
+        vm.label(alice, "Alice");
+
+        (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
+        assumeEtchable(alice, address(flow));
+
+        uint256[] memory stack = new uint256[](1);
+        stack[0] = Sentinel.unwrap(RAIN_FLOW_SENTINEL);
+        interpreterEval2MockCall(stack, new uint256[](0));
+
+        vm.startPrank(alice);
+        vm.expectRevert(abi.encodeWithSelector(MissingSentinel.selector, RAIN_FLOW_SENTINEL));
         flow.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
         vm.stopPrank();
     }


### PR DESCRIPTION
## Summary

Pins the documented "MAY revert if malformed" / "MUST revert if malformed" clauses on `IFlowV5.stackToFlow` and `IFlowV5.flow`. The observable revert is `MissingSentinel(RAIN_FLOW_SENTINEL)` from `LibStackSentinel.consumeSentinelTuples` when any of the three required sentinels is absent.

Five tests:

- `testStackToFlowRevertsOnEmptyStack`
- `testStackToFlowRevertsOnOneSentinelOnly`
- `testStackToFlowRevertsOnTwoSentinelsOnly`
- `testFlowRevertsOnEmptyEvaluatedStack` (fuzzed)
- `testFlowRevertsOnOneSentinelOnlyEvaluatedStack` (fuzzed)

Closes #316 #317 #328.

## Test plan

- [x] all 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
