### PR TITLE
test kvs short-circuit and store.set revert paths in LibFlow.flow

### DIFF
--- a/test/src/concrete/Flow.time.t.sol
+++ b/test/src/concrete/Flow.time.t.sol
@@ -56,9 +56,7 @@ contract FlowTimeTest is FlowTest {
         uint256[] memory stack = generateFlowStack(transferEmpty());
         interpreterEval2MockCall(stack, writeToStore);
 
-        vm.mockCallRevert(
-            address(STORE), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), "STORE_SET_FAILED"
-        );
+        vm.mockCallRevert(address(STORE), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), "STORE_SET_FAILED");
 
         vm.expectRevert("STORE_SET_FAILED");
         flow.flow(evaluable, writeToStore, new SignedContextV1[](0));

--- a/test/src/concrete/Flow.time.t.sol
+++ b/test/src/concrete/Flow.time.t.sol
@@ -27,4 +27,40 @@ contract FlowTimeTest is FlowTest {
 
         flow.flow(evaluable, writeToStore, new SignedContextV1[](0));
     }
+
+    /// `LibFlow.flow` short-circuits the `interpreterStore.set` call when
+    /// `kvs.length == 0`. Pin this with an explicit count=0 expectCall so
+    /// a future refactor that drops the short-circuit is caught.
+    function testFlowBasicFlowTimeNoStoreSetWhenKvsEmpty() public {
+        (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
+
+        uint256[] memory stack = generateFlowStack(transferEmpty());
+        interpreterEval2MockCall(stack, new uint256[](0));
+
+        // Mock set to a no-op so the existing REVERTING_MOCK_BYTECODE on
+        // STORE doesn't accidentally pass the test for the wrong reason.
+        vm.mockCall(address(STORE), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), abi.encode());
+        vm.expectCall(address(STORE), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), 0);
+
+        flow.flow(evaluable, new uint256[](0), new SignedContextV1[](0));
+    }
+
+    /// A revert from `interpreterStore.set` MUST propagate out of `flow`
+    /// rather than being caught and swallowed.
+    /// forge-config: default.fuzz.runs = 100
+    function testFlowBasicFlowTimeStoreSetRevertBubbles(uint256[] memory writeToStore) public {
+        vm.assume(writeToStore.length != 0);
+
+        (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
+
+        uint256[] memory stack = generateFlowStack(transferEmpty());
+        interpreterEval2MockCall(stack, writeToStore);
+
+        vm.mockCallRevert(
+            address(STORE), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), abi.encode("STORE_SET_FAILED")
+        );
+
+        vm.expectRevert(abi.encode("STORE_SET_FAILED"));
+        flow.flow(evaluable, writeToStore, new SignedContextV1[](0));
+    }
 }

--- a/test/src/concrete/Flow.time.t.sol
+++ b/test/src/concrete/Flow.time.t.sol
@@ -57,10 +57,10 @@ contract FlowTimeTest is FlowTest {
         interpreterEval2MockCall(stack, writeToStore);
 
         vm.mockCallRevert(
-            address(STORE), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), abi.encode("STORE_SET_FAILED")
+            address(STORE), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), "STORE_SET_FAILED"
         );
 
-        vm.expectRevert(abi.encode("STORE_SET_FAILED"));
+        vm.expectRevert("STORE_SET_FAILED");
         flow.flow(evaluable, writeToStore, new SignedContextV1[](0));
     }
 }


### PR DESCRIPTION
## Summary

Two new tests pinning `LibFlow.flow`'s store-side behavior:

- **`testFlowBasicFlowTimeNoStoreSetWhenKvsEmpty`** — explicit `count=0` `expectCall` on `STORE.set` when kvs is empty. Locks the existing short-circuit so a future change that drops it is caught. **Mutation verified**: removing the `kvs.length > 0` guard makes the test fail; reverting passes.

- **`testFlowBasicFlowTimeStoreSetRevertBubbles`** — when kvs is non-empty and `store.set` reverts, the revert MUST propagate out of `flow()` rather than be caught and swallowed.

Closes #329.

## Test plan

- [x] both tests pass on current code (one as static, one as 100-run fuzz)
- [x] mutation: drop the `kvs.length > 0` guard → empty-kvs test fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for storage operations, including validation of empty input scenarios and error propagation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->