### PR TITLE
rewrite test src/ imports to relative paths

### DIFF
--- a/test/abstract/FlowTest.sol
+++ b/test/abstract/FlowTest.sol
@@ -11,8 +11,8 @@ import {CloneFactory} from "rain.factory/src/concrete/CloneFactory.sol";
 import {LibLogHelper} from "test/lib/LibLogHelper.sol";
 import {LibStackGeneration} from "test/lib/LibStackGeneration.sol";
 import {Address} from "openzeppelin-contracts/contracts/utils/Address.sol";
-import {FlowTransferV1, IFlowV5, RAIN_FLOW_SENTINEL, Sentinel} from "src/interface/IFlowV5.sol";
-import {Flow} from "src/concrete/Flow.sol";
+import {FlowTransferV1, IFlowV5, RAIN_FLOW_SENTINEL, Sentinel} from "../../src/interface/IFlowV5.sol";
+import {Flow} from "../../src/concrete/Flow.sol";
 import {LibUint256Matrix} from "rain.solmem/lib/LibUint256Matrix.sol";
 import {LibUint256Array} from "rain.solmem/lib/LibUint256Array.sol";
 

--- a/test/abstract/FlowTransferOperation.sol
+++ b/test/abstract/FlowTransferOperation.sol
@@ -9,7 +9,7 @@ import {
     ERC721Transfer,
     ERC1155Transfer,
     RAIN_FLOW_SENTINEL
-} from "src/interface/IFlowV5.sol";
+} from "../../src/interface/IFlowV5.sol";
 import {REVERTING_MOCK_BYTECODE} from "./TestConstants.sol";
 import {Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/test/abstract/FlowUtilsAbstractTest.sol
+++ b/test/abstract/FlowUtilsAbstractTest.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.25;
 
 import {Vm} from "forge-std/Test.sol";
 
-import {FlowTransferV1, RAIN_FLOW_SENTINEL} from "src/interface/IFlowV5.sol";
+import {FlowTransferV1, RAIN_FLOW_SENTINEL} from "../../src/interface/IFlowV5.sol";
 import {Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
 import {LibStackGeneration} from "test/lib/LibStackGeneration.sol";
 import {LibLogHelper} from "test/lib/LibLogHelper.sol";

--- a/test/interface/IFlowV5.t.sol
+++ b/test/interface/IFlowV5.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 
-import {RAIN_FLOW_SENTINEL} from "src/interface/deprecated/v4/IFlowV4.sol";
+import {RAIN_FLOW_SENTINEL} from "../../src/interface/deprecated/v4/IFlowV4.sol";
 import {Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
 
 contract IFlowV5Test is Test {

--- a/test/interface/deprecated/v4/IFlowV4.t.sol
+++ b/test/interface/deprecated/v4/IFlowV4.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 
-import {RAIN_FLOW_SENTINEL} from "src/interface/deprecated/v4/IFlowV4.sol";
+import {RAIN_FLOW_SENTINEL} from "../../../../src/interface/deprecated/v4/IFlowV4.sol";
 import {Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
 
 contract IFlowV4Test is Test {

--- a/test/lib/LibStackGeneration.sol
+++ b/test/lib/LibStackGeneration.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.25;
 
-import {FlowTransferV1} from "src/interface/IFlowV5.sol";
+import {FlowTransferV1} from "../../src/interface/IFlowV5.sol";
 
 library LibStackGeneration {
     function generateFlowStack(uint256 sentinel, FlowTransferV1 memory flowTransfer)

--- a/test/src/concrete/Flow.construction.t.sol
+++ b/test/src/concrete/Flow.construction.t.sol
@@ -6,7 +6,7 @@ import {Vm} from "forge-std/Test.sol";
 
 import {EvaluableConfigV3} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {FlowTest} from "test/abstract/FlowTest.sol";
-import {EmptyFlowConfig} from "src/error/ErrFlow.sol";
+import {EmptyFlowConfig} from "../../../src/error/ErrFlow.sol";
 
 contract FlowConstructionTest is FlowTest {
     function testFlowConstructionEmptyConfigReverts() external {

--- a/test/src/concrete/Flow.context.t.sol
+++ b/test/src/concrete/Flow.context.t.sol
@@ -3,9 +3,9 @@
 pragma solidity =0.8.25;
 
 import {FlowTest} from "test/abstract/FlowTest.sol";
-import {IFlowV5} from "src/interface/IFlowV5.sol";
+import {IFlowV5} from "../../../src/interface/IFlowV5.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
-import {FLOW_MAX_OUTPUTS, FLOW_ENTRYPOINT} from "src/concrete/Flow.sol";
+import {FLOW_MAX_OUTPUTS, FLOW_ENTRYPOINT} from "../../../src/concrete/Flow.sol";
 import {LibEncodedDispatch} from "rain.interpreter.interface/lib/caller/LibEncodedDispatch.sol";
 import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {LibContextWrapper} from "test/lib/LibContextWrapper.sol";

--- a/test/src/concrete/Flow.expression.t.sol
+++ b/test/src/concrete/Flow.expression.t.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {Vm} from "forge-std/Test.sol";
 
 import {FlowTest} from "test/abstract/FlowTest.sol";
-import {IFlowV5} from "src/interface/IFlowV5.sol";
+import {IFlowV5} from "../../../src/interface/IFlowV5.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {LibUint256Matrix} from "rain.solmem/lib/LibUint256Matrix.sol";

--- a/test/src/concrete/Flow.multicall.t.sol
+++ b/test/src/concrete/Flow.multicall.t.sol
@@ -3,8 +3,8 @@
 pragma solidity =0.8.25;
 
 import {FlowTest} from "test/abstract/FlowTest.sol";
-import {IFlowV5} from "src/interface/IFlowV5.sol";
-import {FLOW_MAX_OUTPUTS, FLOW_ENTRYPOINT} from "src/concrete/Flow.sol";
+import {IFlowV5} from "../../../src/interface/IFlowV5.sol";
+import {FLOW_MAX_OUTPUTS, FLOW_ENTRYPOINT} from "../../../src/concrete/Flow.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {LibEncodedDispatch} from "rain.interpreter.interface/lib/caller/LibEncodedDispatch.sol";

--- a/test/src/concrete/Flow.preview.t.sol
+++ b/test/src/concrete/Flow.preview.t.sol
@@ -11,7 +11,7 @@ import {
     ERC1155Transfer,
     RAIN_FLOW_SENTINEL,
     Sentinel
-} from "src/interface/IFlowV5.sol";
+} from "../../../src/interface/IFlowV5.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {LibEvaluable} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 

--- a/test/src/concrete/Flow.signedContext.t.sol
+++ b/test/src/concrete/Flow.signedContext.t.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {Vm} from "forge-std/Test.sol";
 import {FlowTest} from "test/abstract/FlowTest.sol";
 import {SignContextLib} from "test/lib/SignContextLib.sol";
-import {IFlowV5} from "src/interface/IFlowV5.sol";
+import {IFlowV5} from "../../../src/interface/IFlowV5.sol";
 import {EvaluableV2, SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {InvalidSignature} from "rain.interpreter.interface/lib/caller/LibContext.sol";
 

--- a/test/src/concrete/Flow.time.t.sol
+++ b/test/src/concrete/Flow.time.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {FlowTest} from "test/abstract/FlowTest.sol";
-import {IFlowV5} from "src/interface/IFlowV5.sol";
+import {IFlowV5} from "../../../src/interface/IFlowV5.sol";
 import {EvaluableV2, SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
 import {DEFAULT_STATE_NAMESPACE} from "rain.interpreter.interface/interface/IInterpreterV2.sol";
 import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpreterStoreV2.sol";

--- a/test/src/concrete/Flow.transfer.t.sol
+++ b/test/src/concrete/Flow.transfer.t.sol
@@ -11,7 +11,7 @@ import {
     ERC1155Transfer,
     RAIN_FLOW_SENTINEL,
     Sentinel
-} from "src/interface/IFlowV5.sol";
+} from "../../../src/interface/IFlowV5.sol";
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SignedContextV1} from "rain.interpreter.interface/interface/IInterpreterCallerV2.sol";
@@ -21,9 +21,9 @@ import {
     UnsupportedERC721Flow,
     UnsupportedERC1155Flow,
     UnregisteredFlow
-} from "src/error/ErrFlow.sol";
+} from "../../../src/error/ErrFlow.sol";
 
-import {FLOW_ENTRYPOINT, FLOW_MAX_OUTPUTS} from "src/concrete/Flow.sol";
+import {FLOW_ENTRYPOINT, FLOW_MAX_OUTPUTS} from "../../../src/concrete/Flow.sol";
 import {LibEncodedDispatch} from "rain.interpreter.interface/lib/caller/LibEncodedDispatch.sol";
 import {LibContextWrapper} from "test/lib/LibContextWrapper.sol";
 import {IERC721} from "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";


### PR DESCRIPTION
## Summary

Bare `src/` imports break when this repo is consumed as a Foundry git submodule — `src/` resolves to the parent project's source directory, not this submodule's. Every test import now uses a relative path appropriate to its file's depth (`../../src/...`, `../../../src/...`, or `../../../../src/...`).

14 test files updated, 19 imports rewritten.

Closes #411.

## Test plan

- [x] `forge build` clean (114 files compile)
- [x] full suite via `rainix-sol-test` — 31/31

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated import paths in test files from source-root style to relative paths for proper module resolution. No functional changes to test logic or contract behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->