### PR TITLE
move BadMinStackLength to ErrFlow.sol

### DIFF
--- a/src/concrete/Flow.sol
+++ b/src/concrete/Flow.sol
@@ -33,12 +33,7 @@ import {
 } from "openzeppelin-contracts-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
 import {LibUint256Matrix} from "rain.solmem/lib/LibUint256Matrix.sol";
 import {LibNamespace, StateNamespace} from "rain.interpreter.interface/lib/ns/LibNamespace.sol";
-import {
-    UnsupportedFlowInputs,
-    InsufficientFlowOutputs,
-    EmptyFlowConfig,
-    BadMinStackLength
-} from "../error/ErrFlow.sol";
+import {UnsupportedFlowInputs, InsufficientFlowOutputs, EmptyFlowConfig, BadMinStackLength} from "../error/ErrFlow.sol";
 import {IFlowV5, MIN_FLOW_SENTINELS, FlowTransferV1} from "../interface/IFlowV5.sol";
 import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain.factory/src/interface/ICloneableV2.sol";
 import {LibFlow} from "../lib/LibFlow.sol";

--- a/src/concrete/Flow.sol
+++ b/src/concrete/Flow.sol
@@ -33,16 +33,15 @@ import {
 } from "openzeppelin-contracts-upgradeable/contracts/security/ReentrancyGuardUpgradeable.sol";
 import {LibUint256Matrix} from "rain.solmem/lib/LibUint256Matrix.sol";
 import {LibNamespace, StateNamespace} from "rain.interpreter.interface/lib/ns/LibNamespace.sol";
-import {UnsupportedFlowInputs, InsufficientFlowOutputs, EmptyFlowConfig} from "../error/ErrFlow.sol";
+import {
+    UnsupportedFlowInputs,
+    InsufficientFlowOutputs,
+    EmptyFlowConfig,
+    BadMinStackLength
+} from "../error/ErrFlow.sol";
 import {IFlowV5, MIN_FLOW_SENTINELS, FlowTransferV1} from "../interface/IFlowV5.sol";
 import {ICloneableV2, ICLONEABLE_V2_SUCCESS} from "rain.factory/src/interface/ICloneableV2.sol";
 import {LibFlow} from "../lib/LibFlow.sol";
-
-/// Thrown when the min outputs for a flow is fewer than the sentinels.
-/// This is always an implementation bug as the min outputs and sentinel count
-/// should both be compile time constants.
-/// @param flowMinOutputs The min outputs for the flow.
-error BadMinStackLength(uint256 flowMinOutputs);
 
 /// @dev The entrypoint for a flow is always `0` because each flow has its own
 /// evaluable with its own entrypoint. Running multiple flows involves evaluating

--- a/src/error/ErrFlow.sol
+++ b/src/error/ErrFlow.sol
@@ -27,3 +27,9 @@ error InsufficientFlowOutputs();
 /// which would produce a permanently inert clone (every `flow()` call
 /// would revert with `UnregisteredFlow`).
 error EmptyFlowConfig();
+
+/// Thrown when the min outputs for a flow is fewer than the sentinels. This
+/// is always an implementation bug as the min outputs and sentinel count
+/// should both be compile time constants.
+/// @param flowMinOutputs The min outputs for the flow.
+error BadMinStackLength(uint256 flowMinOutputs);


### PR DESCRIPTION
## Summary

Every other error reverted from `Flow.sol` is declared in a dedicated error file (`ErrFlow.sol` or `rain.factory`'s `ICloneableV2.sol`). `BadMinStackLength` was the only outlier — declared inline in the implementation file.

Moved to `src/error/ErrFlow.sol` so consumers (interfaces, ABI bindings, integrators) can get the selector without importing the concrete `Flow` contract and its OZ `Multicall` / `ReentrancyGuard` / interpreter dependencies.

Closes #414.

## Test plan

- [x] `forge build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
