### PR TITLE
remove dead Pointer import from IFlowV5

### DIFF
--- a/src/interface/IFlowV5.sol
+++ b/src/interface/IFlowV5.sol
@@ -6,8 +6,6 @@ import {SignedContextV1, EvaluableConfigV3} from "rain.interpreter.interface/int
 import {EvaluableV2} from "rain.interpreter.interface/lib/caller/LibEvaluable.sol";
 //forge-lint: disable-next-line(unused-import)
 import {Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
-//forge-lint: disable-next-line(unused-import)
-import {Pointer} from "rain.solmem/lib/LibPointer.sol";
 import {
     FlowTransferV1,
 


### PR DESCRIPTION
## Summary

`Pointer` was imported in `IFlowV5.sol` with a `forge-lint: disable-next-line(unused-import)` suppression, but no consumer re-imports it from this interface. Other suppressed imports in the file (`Sentinel`, `RAIN_FLOW_SENTINEL`, `ERC20Transfer`/`ERC721Transfer`/`ERC1155Transfer`, `MIN_FLOW_SENTINELS`) all have downstream callers. The suppression was hiding a genuinely unused import.

Closes #415.

## Test plan

- [x] `forge build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to support interface compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->