### PR TITLE
standardise loop increment to ++i across LibFlow siblings

### DIFF
--- a/src/lib/LibFlow.sol
+++ b/src/lib/LibFlow.sol
@@ -82,7 +82,7 @@ library LibFlow {
     function flowERC20(FlowTransferV1 memory flowTransfer) internal {
         unchecked {
             ERC20Transfer memory transfer;
-            for (uint256 i = 0; i < flowTransfer.erc20.length; i++) {
+            for (uint256 i = 0; i < flowTransfer.erc20.length; ++i) {
                 transfer = flowTransfer.erc20[i];
                 // We don't support `from` as anyone other than `you` or `me`
                 // as this would allow for all kinds of issues re: approvals.
@@ -129,7 +129,7 @@ library LibFlow {
     function flowERC1155(FlowTransferV1 memory flowTransfer) internal {
         unchecked {
             ERC1155Transfer memory transfer;
-            for (uint256 i = 0; i < flowTransfer.erc1155.length; i++) {
+            for (uint256 i = 0; i < flowTransfer.erc1155.length; ++i) {
                 transfer = flowTransfer.erc1155[i];
                 if (transfer.from != msg.sender && transfer.from != address(this)) {
                     revert UnsupportedERC1155Flow();


### PR DESCRIPTION
## Summary

`flowERC721` used `++i`; `flowERC20` and `flowERC1155` used `i++`. All three loops are inside `unchecked` blocks so the codegen is identical, but the sibling functions should look identical. Standardised on `++i`.

Closes #416.

## Test plan

- [x] `forge build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
