### PR TITLE
use forge-std boundPrivateKey for fuzzed keys

### DIFF
--- a/test/src/concrete/Flow.expression.t.sol
+++ b/test/src/concrete/Flow.expression.t.sol
@@ -55,8 +55,7 @@ contract FlowExpressionTest is FlowTest, IInterpreterCallerV2 {
 
         SignedContextV1[] memory signedContext = new SignedContextV1[](matrixCallerContext.length);
         {
-            // Ensure the fuzzed key is within the valid range for secp256k1
-            uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
+            uint256 aliceKey = boundPrivateKey(fuzzedKeyAlice);
             for (uint256 i = 0; i < matrixCallerContext.length; i++) {
                 signedContext[i] = vm.signContext(aliceKey, aliceKey, matrixCallerContext[i]);
             }

--- a/test/src/concrete/Flow.signedContext.t.sol
+++ b/test/src/concrete/Flow.signedContext.t.sol
@@ -23,9 +23,8 @@ contract FlowSignedContextTest is FlowTest {
         vm.assume(fuzzedKeyBob != fuzzedKeyAlice);
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
-        // Ensure the fuzzed key is within the valid range for secp256k1
-        uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
-        uint256 bobKey = (fuzzedKeyBob % (SECP256K1_ORDER - 1)) + 1;
+        uint256 aliceKey = boundPrivateKey(fuzzedKeyAlice);
+        uint256 bobKey = boundPrivateKey(fuzzedKeyBob);
 
         SignedContextV1[] memory signedContexts = new SignedContextV1[](2);
 
@@ -56,9 +55,8 @@ contract FlowSignedContextTest is FlowTest {
         vm.assume(fuzzedKeyBob != fuzzedKeyAlice);
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
-        // Ensure the fuzzed key is within the valid range for secp256k1
-        uint256 aliceKey = (fuzzedKeyAlice % (SECP256K1_ORDER - 1)) + 1;
-        uint256 bobKey = (fuzzedKeyBob % (SECP256K1_ORDER - 1)) + 1;
+        uint256 aliceKey = boundPrivateKey(fuzzedKeyAlice);
+        uint256 bobKey = boundPrivateKey(fuzzedKeyBob);
 
         SignedContextV1[] memory signedContext = new SignedContextV1[](1);
         signedContext[0] = vm.signContext(aliceKey, aliceKey, context0);


### PR DESCRIPTION
## Summary

forge-std's `StdUtils` (already inherited via `Test` → `FlowTest`) exposes `boundPrivateKey(uint256)` — the canonical helper for clamping a fuzzed value into the secp256k1 valid private-key range. Five manual occurrences of `(key % (SECP256K1_ORDER - 1)) + 1` and their identical "// Ensure the fuzzed key is within the valid range for secp256k1" comments are replaced.

Closes #420.

## Test plan

- [x] full suite — 31/31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
