### PR TITLE
rename testFlowBasicFlowTime to reflect actual coverage

### DIFF
--- a/test/src/concrete/Flow.time.t.sol
+++ b/test/src/concrete/Flow.time.t.sol
@@ -9,7 +9,10 @@ import {DEFAULT_STATE_NAMESPACE} from "rain.interpreter.interface/interface/IInt
 import {IInterpreterStoreV2} from "rain.interpreter.interface/interface/IInterpreterStoreV2.sol";
 
 contract FlowTimeTest is FlowTest {
-    function testFlowBasicFlowTime(uint256[] memory writeToStore) public {
+    /// `flow()` writes the eval2 `writes` array to the interpreter store
+    /// under `DEFAULT_STATE_NAMESPACE`. (No time semantics — see file
+    /// note above the contract.)
+    function testFlowBasicWritesKvsToStore(uint256[] memory writeToStore) public {
         vm.assume(writeToStore.length != 0);
 
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();


### PR DESCRIPTION
## Summary

`testFlowBasicFlowTime` had no time-related logic — no `block.timestamp`, no time advancement, no time-bound behaviour. The test asserts that `eval2`'s `writes` array is written to the interpreter store under `DEFAULT_STATE_NAMESPACE` — a store-write coverage test.

Renamed function to `testFlowBasicWritesKvsToStore`. The file `Flow.time.t.sol` is left in place; PR **#449** (#329) adds two more tests on this file with the same `FlowBasicFlowTime` prefix. The file rename to `Flow.store.t.sol` and the rename of the new tests can follow once #449 merges.

Closes #422.

## Test plan

- [x] renamed test passes (2048 fuzz runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
