### PR TITLE
rename testFlowHaltIfEnsureRequirementNotMet to actual coverage

### DIFF
--- a/test/src/concrete/Flow.transfer.t.sol
+++ b/test/src/concrete/Flow.transfer.t.sol
@@ -317,11 +317,14 @@ contract FlowTransferTest is FlowTest {
         vm.stopPrank();
     }
 
-    /**
-     * @notice Tests that the flow halts if it does not meet the 'ensure' requirement.
-     */
+    /// Generic interpreter-revert propagation. The interpreter mock is set
+    /// to revert on `eval2`; the test asserts the revert payload bubbles
+    /// out of `flow()`. This covers any path that produces an interpreter
+    /// revert (out-of-gas, stack underflow, runtime opcode error, failed
+    /// `ensure(...)`, etc.) — not the specific `ensure` opcode in
+    /// isolation.
     /// forge-config: default.fuzz.runs = 100
-    function testFlowHaltIfEnsureRequirementNotMet() external {
+    function testFlowRevertPropagatesFromInterpreter() external {
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
         assumeEtchable(address(0), address(flow));
 


### PR DESCRIPTION
## Summary

`testFlowHaltIfEnsureRequirementNotMet` mocks `eval2` to revert with a generic string. It pins generic interpreter-revert propagation, not the `ensure` opcode in isolation — any interpreter revert (out-of-gas, stack underflow, runtime opcode error, failed `ensure`) takes the same path through `flow()`.

Renamed to `testFlowRevertPropagatesFromInterpreter` and replaced the misleading NatSpec line with one that names the actual coverage.

Closes #423.

## Test plan

- [x] renamed test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
