### PR TITLE
fix Flow constructor NatSpec to match implementation

### DIFF
--- a/src/concrete/Flow.sol
+++ b/src/concrete/Flow.sol
@@ -109,13 +109,11 @@ contract Flow is ERC721Holder, ERC1155Holder, Multicall, ReentrancyGuard, IInter
     /// provide the same evaluable when they evaluate the flow.
     event FlowInitialized(address sender, EvaluableV2 evaluable);
 
-    /// Forwards config to `DeployerDiscoverableMetaV2` and disables
-    /// initializers. The initializers are disabled because inheriting contracts
-    /// are expected to implement some kind of initialization logic that is
-    /// compatible with cloning via. proxy/factory. Disabling initializers
-    /// in the implementation contract forces that the only way to initialize
-    /// the contract is via. a proxy, which should also strongly encourage
-    /// patterns that _atomically_ clone and initialize via. some factory.
+    /// Disables initializers on the implementation contract so that any
+    /// usable instance is a proxy / clone that runs `initialize` exactly
+    /// once. Forcing this through a factory encourages the
+    /// atomically-clone-then-initialize pattern; a directly-deployed
+    /// implementation is unusable.
     constructor() {
         _disableInitializers();
     }


### PR DESCRIPTION
## Summary

The `Flow` constructor NatSpec claimed it "forwards config to `DeployerDiscoverableMetaV2`". Neither is true: the constructor takes no parameters and forwards nothing, and `DeployerDiscoverableMetaV2` is not in the inheritance chain or imported anywhere — a dangling reference to a removed dependency.

NatSpec rewritten to describe what the constructor actually does: disable initializers so the implementation is unusable directly and all usable instances must be proxies / clones initialized via a factory.

Closes #347.

## Test plan

- [x] build clean (NatSpec-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
