### PR TITLE
add @param tag to typed initialize overload

### DIFF
--- a/src/concrete/Flow.sol
+++ b/src/concrete/Flow.sol
@@ -120,9 +120,14 @@ contract Flow is ERC721Holder, ERC1155Holder, Multicall, ReentrancyGuard, IInter
         _disableInitializers();
     }
 
-    /// Overloaded typed initialize function MUST revert with this error.
-    /// As per `ICloneableV2` interface.
-    function initialize(EvaluableConfigV3[] memory) external pure {
+    /// The typed `initialize(EvaluableConfigV3[])` overload exists only to
+    /// surface the parameter shape in the ABI for tooling. It MUST always
+    /// revert with `InitializeSignatureFn` per the `ICloneableV2`
+    /// contract; the canonical entrypoint is `initialize(bytes)`.
+    /// @param evaluableConfigs Ignored — the function reverts before
+    /// reading it. Named for ABI clarity only.
+    function initialize(EvaluableConfigV3[] memory evaluableConfigs) external pure {
+        evaluableConfigs;
         revert InitializeSignatureFn();
     }
 


### PR DESCRIPTION
## Summary

The unnamed `initialize(EvaluableConfigV3[])` overload had a docstring describing the revert behaviour but no `@param` tag for its parameter. Named it `evaluableConfigs` and documented it as ABI-surface-only (the function reverts before reading it). The no-op self-reference quiets the unused-parameter warning.

The companion `BadMinStackLength` `@param` was already present on main — that part of the audit finding was stale.

Closes #349.

## Test plan

- [x] build clean (NatSpec + parameter rename only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
