### PR TITLE
document io byte layout above flowInit assembly

### DIFF
--- a/src/concrete/Flow.sol
+++ b/src/concrete/Flow.sol
@@ -200,6 +200,13 @@ contract Flow is ERC721Holder, ERC1155Holder, Multicall, ReentrancyGuard, IInter
                     config.deployer.deployExpression2(config.bytecode, config.constants);
 
                 {
+                    // `io` is a `bytes` array. The deployer encodes per-
+                    // source `(inputs, outputs)` pairs as consecutive
+                    // bytes, with source 0 first. Flow only uses one
+                    // source (`FLOW_ENTRYPOINT == 0`), so byte 0 is
+                    // `flowInputs` and byte 1 is `flowOutputs`.
+                    // `add(io, 0x20)` skips the bytes-length word to
+                    // land on the first data word.
                     uint256 flowInputs;
                     uint256 flowOutputs;
                     assembly ("memory-safe") {


### PR DESCRIPTION
## Summary

The assembly block in `flowInit` reading `flowInputs` / `flowOutputs` from the deployer-returned `io` bytes had no comment explaining the layout — why `add(io, 0x20)` skips the bytes-length word and why bytes 0 and 1 are the relevant offsets.

Added a per-block comment naming the deployer's per-source `(inputs, outputs)` byte-pair convention and noting that the single-source flow entrypoint (`FLOW_ENTRYPOINT == 0`) pins source 0.

Closes #350.

## Test plan

- [x] build clean (comment-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved internal code clarity with enhanced comments and explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->