### PR TITLE
fix LibFlow.flow @param interpreterStore type reference

### DIFF
--- a/src/lib/LibFlow.sol
+++ b/src/lib/LibFlow.sol
@@ -147,7 +147,7 @@ library LibFlow {
     /// observe every flow invocation (e.g. for audit logging) cannot rely on
     /// `set` being called for empty kvs.
     /// @param flowTransfer The `FlowTransferV1` to process.
-    /// @param interpreterStore The `IInterpreterStoreV1` to set state on.
+    /// @param interpreterStore The `IInterpreterStoreV2` to set state on.
     /// @param kvs The key value pairs to set on the interpreter store.
     function flow(FlowTransferV1 memory flowTransfer, IInterpreterStoreV2 interpreterStore, uint256[] memory kvs)
         internal


### PR DESCRIPTION
## Summary

The `@param interpreterStore` NatSpec on `LibFlow.flow` referenced `IInterpreterStoreV1`; the parameter type and the import are both V2. Stale doc from an earlier migration.

Closes #377.

## Test plan

- [x] NatSpec-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
