### PR TITLE
document the safeTransfer self-flow branch in LibFlow.flowERC20 NatSpec

### DIFF
--- a/src/lib/LibFlow.sol
+++ b/src/lib/LibFlow.sol
@@ -75,8 +75,11 @@ library LibFlow {
 
     /// Processes the ERC20 transfers in the flow.
     /// Reverts if the `from` address is not either the `msg.sender` or the
-    /// flow contract. Uses `IERC20.safeTransferFrom` to transfer the tokens to
-    /// ensure that reverts from the token are respected.
+    /// flow contract. Uses `IERC20.safeTransferFrom(from, to, amount)` when
+    /// `from == msg.sender` and `IERC20.safeTransfer(to, amount)` when
+    /// `from == address(this)` — the self-flow branch must use
+    /// `safeTransfer` because OZ `transferFrom` consumes allowance even
+    /// when `from == msg.sender`. Both branches surface token reverts.
     /// @param flowTransfer The `FlowTransferV1` to process. Tokens other than
     /// ERC20 tokens are ignored.
     function flowERC20(FlowTransferV1 memory flowTransfer) internal {


### PR DESCRIPTION
## Summary

`LibFlow.flowERC20` NatSpec only mentioned `safeTransferFrom`. The implementation also calls `safeTransfer` when `from == address(this)` (OZ `transferFrom` consumes allowance even when `from == msg.sender`, so the self-flow branch must use `safeTransfer` instead). NatSpec now states both branches and the reason for the asymmetry.

Closes #379.

## Test plan

- [x] NatSpec-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for ERC20 transfer operations with greater clarity on execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->