### PR TITLE
specify ordering guarantees in LibFlow.flow NatSpec

### DIFF
--- a/src/lib/LibFlow.sol
+++ b/src/lib/LibFlow.sol
@@ -141,8 +141,12 @@ library LibFlow {
 
     /// Processes a flow transfer. Firstly sets state for the interpreter on the
     /// interpreter store. Then processes the ERC20, ERC721 and ERC1155 transfers
-    /// in the flow. Guarantees ordering of the transfers but DOES NOT prevent
-    /// reentrancy attacks. This is the responsibility of the caller.
+    /// in this order: all ERC20 transfers in `flowTransfer.erc20` array
+    /// index order, then all ERC721 transfers in `flowTransfer.erc721`
+    /// array index order, then all ERC1155 transfers in
+    /// `flowTransfer.erc1155` array index order.
+    /// DOES NOT prevent reentrancy attacks. This is the responsibility of
+    /// the caller.
     /// `set` is skipped entirely when `kvs.length == 0`. Stores that need to
     /// observe every flow invocation (e.g. for audit logging) cannot rely on
     /// `set` being called for empty kvs.


### PR DESCRIPTION
## Summary

`LibFlow.flow` NatSpec said "Guarantees ordering of the transfers" without naming which ordering. The function actually guarantees two distinct orderings:

1. **Token-class**: all ERC20 transfers complete before any ERC721, all ERC721 before any ERC1155.
2. **Within-class**: transfers occur in array index order.

NatSpec now spells out both so a caller relying on either property doesn't have to read the source.

Closes #381.

## Test plan

- [x] NatSpec-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
