### PR TITLE
fix IFlowV5 rainlang example to include three sentinels

### DIFF
--- a/src/interface/IFlowV5.sol
+++ b/src/interface/IFlowV5.sol
@@ -113,13 +113,15 @@ import {UnregisteredFlow} from "../error/ErrFlow.sol";
 /// ```
 /// /* sentinel is always the same. */
 /// sentinel: 0xfea74d0c9bf4a3c28f0dd0674db22a3d7f8bf259c56af19f4ac1e735b156974f,
-/// /* erc1155 group sits at the bottom of the stack — written first in
-///    rainlang, consumed last. Just a sentinel here as there's nothing to do. */
+/// /* erc1155 group at the bottom — terminator sentinel, no tuples. */
 /// _: sentinel,
-/// /* erc721 group sits in the middle, with the token id as the last value */
+/// /* erc721 group — terminator sentinel, then one tuple
+///    (token, from, to, id). */
+/// _: sentinel,
 /// _: 0x1234 0xdeadbeef context<0 1>() 5678,
-/// /* erc20 group sits at the top of the stack — written last in rainlang,
-///    consumed first. The amount is the last value of the tuple. */
+/// /* erc20 group at the top — terminator sentinel, then one tuple
+///    (token, from, to, amount). */
+/// _: sentinel,
 /// _: 0xf00baa context<0 1>() 0xdeadbeef 1e18;
 /// ```
 ///


### PR DESCRIPTION
## Summary

The `IFlowV5` rainlang example showed only one sentinel as a stack item. A valid flow stack requires three sentinels (one terminator per token-type group): `LibFlow.stackToFlow` calls `consumeSentinelTuples` three times.

Following the previous example produced an invalid stack — `consumeSentinelTuples` for erc721 and erc20 would pull from below the intended boundary rather than terminating cleanly.

The fix mirrors `test/lib/LibStackGeneration.sol::generateFlowStack`:

- bottom: erc1155 terminator sentinel + erc1155 tuples
- middle: erc721 terminator sentinel + erc721 tuples
- top: erc20 terminator sentinel + erc20 tuples

Closes #424.

## Test plan

- [x] NatSpec-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
