### PR TITLE
deploy: always sign with PRIVATE_KEY (never PRIVATE_KEY_DEV)

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
-      DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
+      DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
-      DEPLOYMENT_KEY: ${{ github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV }}
+      DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -17,9 +17,23 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          useDaemon: false
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
 
       - run: nix develop --command rainix-sol-prelude
 

--- a/test/src/concrete/Flow.time.t.sol
+++ b/test/src/concrete/Flow.time.t.sol
@@ -37,7 +37,7 @@ contract FlowTimeTest is FlowTest {
     function testFlowBasicFlowTimeNoStoreSetWhenKvsEmpty() public {
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
-        uint256[] memory stack = generateFlowStack(transferEmpty());
+        uint256[] memory stack = LibStackGeneration.generateFlowStack(Sentinel.unwrap(RAIN_FLOW_SENTINEL), transferEmpty());
         interpreterEval2MockCall(stack, new uint256[](0));
 
         // Mock set to a no-op so the existing REVERTING_MOCK_BYTECODE on
@@ -56,7 +56,7 @@ contract FlowTimeTest is FlowTest {
 
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
-        uint256[] memory stack = generateFlowStack(transferEmpty());
+        uint256[] memory stack = LibStackGeneration.generateFlowStack(Sentinel.unwrap(RAIN_FLOW_SENTINEL), transferEmpty());
         interpreterEval2MockCall(stack, writeToStore);
 
         vm.mockCallRevert(address(STORE), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), "STORE_SET_FAILED");

--- a/test/src/concrete/Flow.time.t.sol
+++ b/test/src/concrete/Flow.time.t.sol
@@ -37,7 +37,8 @@ contract FlowTimeTest is FlowTest {
     function testFlowBasicFlowTimeNoStoreSetWhenKvsEmpty() public {
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
-        uint256[] memory stack = LibStackGeneration.generateFlowStack(Sentinel.unwrap(RAIN_FLOW_SENTINEL), transferEmpty());
+        uint256[] memory stack =
+            LibStackGeneration.generateFlowStack(Sentinel.unwrap(RAIN_FLOW_SENTINEL), transferEmpty());
         interpreterEval2MockCall(stack, new uint256[](0));
 
         // Mock set to a no-op so the existing REVERTING_MOCK_BYTECODE on
@@ -56,7 +57,8 @@ contract FlowTimeTest is FlowTest {
 
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
-        uint256[] memory stack = LibStackGeneration.generateFlowStack(Sentinel.unwrap(RAIN_FLOW_SENTINEL), transferEmpty());
+        uint256[] memory stack =
+            LibStackGeneration.generateFlowStack(Sentinel.unwrap(RAIN_FLOW_SENTINEL), transferEmpty());
         interpreterEval2MockCall(stack, writeToStore);
 
         vm.mockCallRevert(address(STORE), abi.encodeWithSelector(IInterpreterStoreV2.set.selector), "STORE_SET_FAILED");


### PR DESCRIPTION
Per project policy, deploy workflows always sign with `secrets.PRIVATE_KEY`. Replaces the `github.ref == 'refs/heads/main' && secrets.PRIVATE_KEY || secrets.PRIVATE_KEY_DEV` fallback in: manual-sol-artifacts.yaml rainix.yaml

Fresh PR off current main (supersedes the stale #472, which was based on a pre-FlowTest-refactor main and no longer compiled). Last repo referencing the org `PRIVATE_KEY_DEV` secret, so this clears it for deletion.