### PR TITLE
fix: remove redundant statement flagged by slither (unblocks rainix-sol-static)

### DIFF
--- a/src/concrete/Flow.sol
+++ b/src/concrete/Flow.sol
@@ -114,11 +114,9 @@ contract Flow is ERC721Holder, ERC1155Holder, Multicall, ReentrancyGuard, IInter
     /// The typed `initialize(EvaluableConfigV3[])` overload exists only to
     /// surface the parameter shape in the ABI for tooling. It MUST always
     /// revert with `InitializeSignatureFn` per the `ICloneableV2`
-    /// contract; the canonical entrypoint is `initialize(bytes)`.
-    /// @param evaluableConfigs Ignored — the function reverts before
-    /// reading it. Named for ABI clarity only.
-    function initialize(EvaluableConfigV3[] memory evaluableConfigs) external pure {
-        evaluableConfigs;
+    /// contract; the canonical entrypoint is `initialize(bytes)`. The
+    /// parameter is unnamed because the function reverts before reading it.
+    function initialize(EvaluableConfigV3[] memory) external pure {
         revert InitializeSignatureFn();
     }
 


### PR DESCRIPTION
The recent slither bump in the rainix flake enables the `redundant-statements` detector, which now flags a no-op standalone statement on `src/concrete/Flow.sol`:

```
Detector: redundant-statements
Redundant expression "evaluableConfigs (src/concrete/Flow.sol#121)" in Flow (src/concrete/Flow.sol#84-278)
```

`slither .` exits non-zero **before** `forge fmt --check` runs in `rainix-sol-static`, so this fails static on `main` and blocks every flow PR (#459 included).

### Origin of the line
The no-op `evaluableConfigs;` was added in #465 (commit `7c309b21`, "add @param tag to typed initialize overload", Closes #349) — *not* the doc-only #466. That PR named the previously-unnamed parameter of the typed `initialize(EvaluableConfigV3[])` revert overload and added the self-reference purely to silence the resulting unused-parameter warning (per its own commit message: "The no-op self-reference quiets the unused-parameter warning").

### Fix
Remove the no-op and drop the now-unused parameter name (reverting to `EvaluableConfigV3[] memory` — unnamed parameters never trigger an unused-parameter warning, which is the convention this file used before #465). The NatSpec is updated to drop the dangling `@param` and note the parameter is unnamed because the function reverts before reading it. No compiler-warning re-introduction: `forge build` is clean.

### Verification (rainix sol-shell)
- `slither .` → **0 results** (was 1; no new findings introduced)
- `forge build` → `Compiler run successful!`, no unused-var/param warning from `src/` (the two `unsafe-typecast` warnings are pre-existing, in test files)
- `forge fmt --check` → exit 0
- `forge test` → **55 passed, 0 failed, 0 skipped**

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated function signature for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->