### PR TITLE
test V5 sentinel + min sentinels through IFlowV5 re-export

### DIFF
--- a/test/interface/IFlowV5.t.sol
+++ b/test/interface/IFlowV5.t.sol
@@ -4,13 +4,25 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 
-import {RAIN_FLOW_SENTINEL} from "../../src/interface/deprecated/v4/IFlowV4.sol";
+import {RAIN_FLOW_SENTINEL, MIN_FLOW_SENTINELS} from "../../src/interface/IFlowV5.sol";
 import {Sentinel} from "rain.solmem/lib/LibStackSentinel.sol";
 
 contract IFlowV5Test is Test {
+    /// `IFlowV5` re-exports `RAIN_FLOW_SENTINEL` from `IFlowV4`. This pins the
+    /// value through the V5 re-export surface so a change to the V5 re-export
+    /// (intentional or accidental) is caught here, not silently passed through
+    /// by importing the V4 constant directly.
     function testSentinelValue() external {
         assertEq(
             0xfea74d0c9bf4a3c28f0dd0674db22a3d7f8bf259c56af19f4ac1e735b156974f, Sentinel.unwrap(RAIN_FLOW_SENTINEL)
         );
+    }
+
+    /// `IFlowV5` also re-exports `MIN_FLOW_SENTINELS`. The three required
+    /// sentinels (ERC20, ERC721, ERC1155 sections) make this `3`. Pinning it
+    /// through the V5 interface guards the re-export the same way as the
+    /// sentinel value above.
+    function testMinFlowSentinelsValue() external {
+        assertEq(MIN_FLOW_SENTINELS, 3);
     }
 }


### PR DESCRIPTION
## What

`test/interface/IFlowV5.t.sol` imported `RAIN_FLOW_SENTINEL` directly from `src/interface/deprecated/v4/IFlowV4.sol` — the V5 test never exercised the V5 interface at all. The file was byte-identical to `IFlowV4.t.sol` (modulo the relative import depth), so if `IFlowV5.sol` ever changed its sentinel re-export (intentionally or by mistake), the V5 test would still pass because it bypassed V5 entirely.

This PR changes the import to come from `src/interface/IFlowV5.sol`, exercising the re-export surface the test is named to pin. It also adds a pin for the `MIN_FLOW_SENTINELS` re-export (`== 3`) through V5, since that constant is re-exported on the same chain (`V3 → V4 → V5`) and was previously untested via V5.

Test-only. No source changes.

## Mutation validation

Both assertions were proven to read through the V5 interface by mutating the V5 re-export and confirming the relevant test fails, then restoring:

| Mutation in `IFlowV5.sol` | Test | Result |
|---|---|---|
| `RAIN_FLOW_SENTINEL` re-export replaced with a wrong local constant | `testSentinelValue` | FAIL (killed) |
| `MIN_FLOW_SENTINELS` re-export replaced with `99` | `testMinFlowSentinelsValue` | FAIL (killed) |

Before the import change (importing from V4 directly), neither mutation would have been caught — that is the gap this PR closes.

## Verification

- `forge build`: clean.
- `forge test`: 56 passed, 0 failed (the V5 suite is now 2 tests, both green).
- `forge fmt --check` on the changed file: clean.

Note: `main` is currently red on `rainix-sol-static` due to a pre-existing slither redundant-statement finding fixed by #476 (not yet merged). This PR's CI will show that same pre-existing static red until #476 lands — it is unrelated to this change, which touches only a test file.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)