### PR TITLE
Fix flaky signed-context fuzz tests: constrain bounded keys, not raw inputs

### DIFF
--- a/test/src/concrete/Flow.signedContext.t.sol
+++ b/test/src/concrete/Flow.signedContext.t.sol
@@ -22,11 +22,15 @@ contract FlowSignedContextTest is FlowTest {
         uint256 fuzzedKeyAlice,
         uint256 fuzzedKeyBob
     ) public {
-        vm.assume(fuzzedKeyBob != fuzzedKeyAlice);
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
         uint256 aliceKey = boundPrivateKey(fuzzedKeyAlice);
         uint256 bobKey = boundPrivateKey(fuzzedKeyBob);
+        // `boundPrivateKey` is not injective over the full uint256 domain, so
+        // distinct fuzz inputs can fold onto the same key. The bad-signature
+        // assertion below only holds when the two keys actually differ, so
+        // constrain the bounded keys (not the raw inputs).
+        vm.assume(aliceKey != bobKey);
 
         SignedContextV1[] memory signedContexts = new SignedContextV1[](2);
 
@@ -55,11 +59,15 @@ contract FlowSignedContextTest is FlowTest {
         uint256 fuzzedKeyAlice,
         uint256 fuzzedKeyBob
     ) public {
-        vm.assume(fuzzedKeyBob != fuzzedKeyAlice);
         (IFlowV5 flow, EvaluableV2 memory evaluable) = deployFlow();
 
         uint256 aliceKey = boundPrivateKey(fuzzedKeyAlice);
         uint256 bobKey = boundPrivateKey(fuzzedKeyBob);
+        // `boundPrivateKey` is not injective over the full uint256 domain, so
+        // distinct fuzz inputs can fold onto the same key. The bad-signature
+        // assertion below only holds when the two keys actually differ, so
+        // constrain the bounded keys (not the raw inputs).
+        vm.assume(aliceKey != bobKey);
 
         SignedContextV1[] memory signedContext = new SignedContextV1[](1);
         signedContext[0] = vm.signContext(aliceKey, aliceKey, context0);


### PR DESCRIPTION
## What

`testFlowBasicValidateMultipleSignedContexts` (and its single-context sibling `testFlowBasicValidateSignedContexts`) in `test/src/concrete/Flow.signedContext.t.sol` are a latent/flaky red on `rainix-sol-test`. They pass at the configured `forge-config: default.fuzz.runs = 100` under the pinned `seed = "0xdeadbeef"`, but fail deterministically once enough fuzz runs reach a colliding input. CI fuzzes with a random seed, so this surfaces intermittently.

## Root cause (broken test, not a code bug)

Both tests guarded the *raw* fuzz inputs:

```solidity
vm.assume(fuzzedKeyBob != fuzzedKeyAlice);
uint256 aliceKey = boundPrivateKey(fuzzedKeyAlice);
uint256 bobKey   = boundPrivateKey(fuzzedKeyBob);
```

`forge-std`'s `boundPrivateKey` is `_bound(x, 1, SECP256K1_ORDER - 1)`, which is **not injective** over the full `uint256` domain — e.g. `boundPrivateKey(0) == boundPrivateKey(1) == 1`. So distinct raw inputs (passing `vm.assume`) can fold onto the same private key. When they do, the "bad" second signed context `vm.signContext(aliceKey, bobKey, ...)` is actually signed by the same key it declares as signer, so `LibContext.build`'s `SignatureChecker.isValidSignatureNow` correctly validates it — and the expected `InvalidSignature` revert never fires ("next call did not revert as expected").

The validation code is correct; the test's distinctness precondition was asserted pre-bound but consumed post-bound. Diagnosis and repro are in #479. The captured counterexample under `0xdeadbeef` is `fuzzedKeyAlice = 0, fuzzedKeyBob = 1`.

## Fix

Move the `vm.assume` onto the bounded keys (`aliceKey != bobKey`) in both tests, so the degenerate collision is discarded rather than asserted on, while the bad-signature revert path is still fully exercised across the input domain. The assertion itself is unchanged (not weakened).

## Verification

- Before fix, bumping the per-test runs and running `forge test --match-test testFlowBasicValidateMultipleSignedContexts --fuzz-seed 0xdeadbeef`: FAIL at run 19, counterexample `[..., 0, 1]`.
- After fix, same test at `runs = 100000` under `seed 0xdeadbeef`: **both tests pass** (0 failed).
- Both tests pass across seeds `0xdeadbeef, 0x1, 0x2, 0xc0ffee, 0xbadc0de, 0x12345` at the configured 100 runs.
- `forge fmt --check` clean. (`rainix-sol-static` slither red is pre-existing and unrelated — tracked in #476.)

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness of signed-context fuzz tests with refined constraint handling for cryptographic key validation.
* **Documentation**
  * Added clarifying comments explaining key validation behavior and test assumptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->