### PR TITLE
refactor(test): extract _buildFlowStack helper to DRY duplicate stack builders

### DIFF
--- a/test/abstract/FlowTest.sol
+++ b/test/abstract/FlowTest.sol
@@ -119,14 +119,18 @@ abstract contract FlowTest is FlowTransferOperation, InterpreterMockTest {
         vm.assume(account != address(0x000000000000000000636F6e736F6c652e6c6f67));
     }
 
+    function _buildFlowStack(FlowTransferV1 memory transfer) private pure returns (uint256[] memory, bytes32) {
+        bytes32 transferHash = keccak256(abi.encode(transfer));
+        uint256[] memory stack = Sentinel.unwrap(RAIN_FLOW_SENTINEL).generateFlowStack(transfer);
+        return (stack, transferHash);
+    }
+
     function burnFlowStack(address, uint256, uint256, FlowTransferV1 memory transfer)
         internal
         pure
         returns (uint256[] memory, bytes32)
     {
-        bytes32 transferHash = keccak256(abi.encode(transfer));
-        uint256[] memory stack = Sentinel.unwrap(RAIN_FLOW_SENTINEL).generateFlowStack(transfer);
-        return (stack, transferHash);
+        return _buildFlowStack(transfer);
     }
 
     function mintFlowStack(address, uint256, uint256, FlowTransferV1 memory transfer)
@@ -134,9 +138,7 @@ abstract contract FlowTest is FlowTransferOperation, InterpreterMockTest {
         pure
         returns (uint256[] memory, bytes32)
     {
-        bytes32 transferHash = keccak256(abi.encode(transfer));
-        uint256[] memory stack = Sentinel.unwrap(RAIN_FLOW_SENTINEL).generateFlowStack(transfer);
-        return (stack, transferHash);
+        return _buildFlowStack(transfer);
     }
 
     function buildConfig(string memory, string memory, string memory, address, EvaluableConfigV3[] memory flowConfig)
@@ -179,8 +181,6 @@ abstract contract FlowTest is FlowTransferOperation, InterpreterMockTest {
         pure
         returns (uint256[] memory, bytes32)
     {
-        bytes32 transferHash = keccak256(abi.encode(transfer));
-        uint256[] memory stack = Sentinel.unwrap(RAIN_FLOW_SENTINEL).generateFlowStack(transfer);
-        return (stack, transferHash);
+        return _buildFlowStack(transfer);
     }
 }


### PR DESCRIPTION
Closes #258

`burnFlowStack`, `mintFlowStack`, and `mintAndBurnFlowStack` in `test/abstract/FlowTest.sol` had identical bodies. Extract a private `_buildFlowStack` helper and delegate all three to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified flow stack generation by consolidating repeated logic into a shared helper.
  * Improved consistency across burn, mint, and combined flow stack outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->