### PR TITLE
ci: adopt rainix nix-cachix-setup composite in manual-sol-artifacts, drop deprecated DeterminateSystems nix installer

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -23,8 +23,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
+        with:
+          checkout: 'false'
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: nix develop --command rainix-sol-prelude
       - run: nix develop --command rainix-sol-artifacts


### PR DESCRIPTION
Closes #484

## What

Replaces the deprecated `DeterminateSystems/nix-installer-action@v4` (+ `magic-nix-cache-action@v2`) in `.github/workflows/manual-sol-artifacts.yaml` with the org-standard shared composite `rainlanguage/rainix/.github/actions/nix-cachix-setup@main`, which bundles nix-quick-install + Cachix + `cache-nix-action` and pins every third-party action to an exact SHA (single source of truth — "rainix owns shared CI"). The pre-existing `actions/checkout@v4` step (with `submodules: recursive` + `fetch-depth: 0`) is kept, so the composite is called with `checkout: 'false'`. The two `nix develop --command rainix-sol-{prelude,artifacts}` deploy steps and all deploy secrets/env (`ETH_RPC_URL`, `ETHERSCAN_API_KEY`, `DEPLOYMENT_KEY`) are untouched.

This is the same swap already applied and green on the sibling PRs rainlanguage/sqlite-web#31, rainlanguage/rainlang-codemirror#32, rainlanguage/rain.subgraph.docker#13, and rainlanguage/rain.webapp#357.

## QA

CI-infrastructure-only change: it touches a single GitHub Actions workflow file and no source or test code, so there is no behavioral code surface to mutation-test — the oracle is the workflow run itself.

- **Weaker oracle noted honestly:** `manual-sol-artifacts.yaml` is `workflow_dispatch`-triggered (a manual per-network deploy), so this PR's push does **not** auto-exercise the swap the way an `on: push` CI workflow would. The equivalence argument below carries the confidence instead.
- **Independent confirmation:** the identical installer + `magic-nix-cache` → composite swap is already green on the sibling PRs above; the composite's input contract (`checkout`, `cachix-auth-token`) matches `nix-cachix-setup/action.yml` on `rainix@main`, and this deploy workflow's shape (single checkout + installer, no custom `extra-conf`) is exactly the shape the composite supports.
- **Equivalence:** the composite provides the same capabilities the two removed steps did (Nix install + a Nix store cache) plus the org's pinned-SHA hardening. `checkout: 'false'` preserves the existing `actions/checkout@v4` (submodules + full depth). An empty `CACHIX_AUTH_TOKEN` degrades to a read-only Cachix pull (the composite's documented default). The deploy `run` steps and all network-selecting secrets are unchanged, so deploy behavior is identical — only the Nix install mechanism moves to the org standard.
- **Category check:** issue asks to replace the deprecated installer with the org-standard install (preferred: adopt the shared composite) at the one referenced location and verify CI stays green — done → Closes #484.

Co-Authored-By: Claude <noreply@anthropic.com>
